### PR TITLE
feat: add light appearance support with xcassets colors

### DIFF
--- a/BifcodePackage/Package.swift
+++ b/BifcodePackage/Package.swift
@@ -19,6 +19,9 @@ let package = Package(
             name: "BifcodeFeature",
             dependencies: [
                 .product(name: "CodeEditSourceEditor", package: "CodeEditSourceEditor"),
+            ],
+            resources: [
+                .process("Resources"),
             ]
         ),
         .testTarget(

--- a/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
@@ -30,7 +30,7 @@ public struct ContentView: View {
             panelsView
                 .padding()
         }
-        .background(Color(white: 0.1))
+        .background(Color.contentBackground)
         .frame(minHeight: 400)
         .onChange(of: selectedLanguage) { _, newValue in
             viewModel.setLanguage(newValue)

--- a/BifcodePackage/Sources/BifcodeFeature/Extensions/Color+Semantic.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Extensions/Color+Semantic.swift
@@ -4,39 +4,78 @@ public extension Color {
     // MARK: - Indicator Colors
 
     /// Green checkmark indicator for "Do's"
-    static let indicatorDo = Color(red: 0.2, green: 0.8, blue: 0.4)
+    /// Light: Slightly darker green for better contrast
+    /// Dark: Bright green
+    static let indicatorDo = Color("IndicatorDo", bundle: .module)
 
     /// Red X indicator for "Don'ts"
-    static let indicatorDont = Color(red: 0.9, green: 0.3, blue: 0.3)
+    /// Light: Slightly darker red for better contrast
+    /// Dark: Bright red
+    static let indicatorDont = Color("IndicatorDont", bundle: .module)
 
     // MARK: - Editor Colors
 
-    /// Code editor background
-    static let editorCloseButton = Color(red: 0.9, green: 0.3, blue: 0.3)
+    /// Close button color (traffic light placeholder)
+    /// Light: Slightly darker red
+    /// Dark: Bright red
+    static let editorCloseButton = Color("EditorCloseButton", bundle: .module)
 
     /// Code editor background
-    static let editorBackground = Color(red: 0.12, green: 0.12, blue: 0.14)
+    /// Light: Off-white
+    /// Dark: Dark gray
+    static let editorBackground = Color("EditorBackground", bundle: .module)
 
     /// Line number text color
-    static let editorLineNumber = Color(white: 0.4)
+    /// Light: Medium gray
+    /// Dark: Light gray
+    static let editorLineNumber = Color("EditorLineNumber", bundle: .module)
 
-    /// Default code text color
-    static let editorText = Color(white: 0.9)
+    /// Default code text color (overridden by syntax theme)
+    /// Light: Dark gray
+    /// Dark: Off-white
+    static let editorText = Color("EditorText", bundle: .module)
 
     /// Editor gutter background
-    static let editorGutter = Color(red: 0.1, green: 0.1, blue: 0.12)
+    /// Light: Slightly darker than editor background
+    /// Dark: Slightly darker than editor background
+    static let editorGutter = Color("EditorGutter", bundle: .module)
 
     // MARK: - Window Colors
 
     /// Window background
-    static let windowBackground = Color(red: 0.15, green: 0.15, blue: 0.17)
+    /// Light: Light gray
+    /// Dark: Dark gray
+    static let windowBackground = Color("WindowBackground", bundle: .module)
 
     /// Title bar background
-    static let titleBarBackground = Color(red: 0.18, green: 0.18, blue: 0.2)
+    /// Light: Slightly darker than window
+    /// Dark: Slightly lighter than window
+    static let titleBarBackground = Color("TitleBarBackground", bundle: .module)
 
     /// Title text color
-    static let titleText = Color(white: 0.85)
+    /// Light: Dark gray
+    /// Dark: Off-white
+    static let titleText = Color("TitleText", bundle: .module)
 
     /// Window border color
-    static let windowBorder = Color(white: 0.25)
+    /// Light: Light gray
+    /// Dark: Medium gray
+    static let windowBorder = Color("WindowBorder", bundle: .module)
+
+    // MARK: - UI Colors
+
+    /// Toolbar background
+    /// Light: Light gray
+    /// Dark: Dark gray
+    static let toolbarBackground = Color("ToolbarBackground", bundle: .module)
+
+    /// Main content area background
+    /// Light: Off-white
+    /// Dark: Near black
+    static let contentBackground = Color("ContentBackground", bundle: .module)
+
+    /// Secondary text color
+    /// Light: Semi-transparent black
+    /// Dark: Semi-transparent white
+    static let secondaryText = Color("SecondaryText", bundle: .module)
 }

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/ContentBackground.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/ContentBackground.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.100",
+          "green" : "0.100",
+          "red" : "0.100"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.900",
+          "green" : "0.900",
+          "red" : "0.895"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.100",
+          "green" : "0.100",
+          "red" : "0.100"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/EditorBackground.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/EditorBackground.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.140",
+          "green" : "0.120",
+          "red" : "0.120"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.980",
+          "green" : "0.980",
+          "red" : "0.975"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.140",
+          "green" : "0.120",
+          "red" : "0.120"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/EditorCloseButton.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/EditorCloseButton.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.300",
+          "green" : "0.300",
+          "red" : "0.900"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.250",
+          "green" : "0.250",
+          "red" : "0.850"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.300",
+          "green" : "0.300",
+          "red" : "0.900"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/EditorGutter.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/EditorGutter.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.120",
+          "green" : "0.100",
+          "red" : "0.100"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.950",
+          "green" : "0.950",
+          "red" : "0.945"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.120",
+          "green" : "0.100",
+          "red" : "0.100"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/EditorLineNumber.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/EditorLineNumber.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.400",
+          "green" : "0.400",
+          "red" : "0.400"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.550",
+          "green" : "0.550",
+          "red" : "0.550"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.400",
+          "green" : "0.400",
+          "red" : "0.400"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/EditorText.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/EditorText.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.900",
+          "green" : "0.900",
+          "red" : "0.900"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.150",
+          "green" : "0.150",
+          "red" : "0.150"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.900",
+          "green" : "0.900",
+          "red" : "0.900"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/IndicatorDo.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/IndicatorDo.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.400",
+          "green" : "0.800",
+          "red" : "0.200"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.350",
+          "green" : "0.700",
+          "red" : "0.150"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.400",
+          "green" : "0.800",
+          "red" : "0.200"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/IndicatorDont.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/IndicatorDont.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.300",
+          "green" : "0.300",
+          "red" : "0.900"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.250",
+          "green" : "0.250",
+          "red" : "0.850"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.300",
+          "green" : "0.300",
+          "red" : "0.900"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/SecondaryText.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/SecondaryText.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.600",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.600",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.600",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/TitleBarBackground.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/TitleBarBackground.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.180",
+          "red" : "0.180"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.920",
+          "green" : "0.920",
+          "red" : "0.915"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.180",
+          "red" : "0.180"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/TitleText.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/TitleText.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.850",
+          "green" : "0.850",
+          "red" : "0.850"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.200",
+          "red" : "0.200"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.850",
+          "green" : "0.850",
+          "red" : "0.850"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/ToolbarBackground.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/ToolbarBackground.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.150",
+          "green" : "0.150",
+          "red" : "0.150"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.940",
+          "green" : "0.940",
+          "red" : "0.935"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.150",
+          "green" : "0.150",
+          "red" : "0.150"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/WindowBackground.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/WindowBackground.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.170",
+          "green" : "0.150",
+          "red" : "0.150"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.960",
+          "green" : "0.960",
+          "red" : "0.955"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.170",
+          "green" : "0.150",
+          "red" : "0.150"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/WindowBorder.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/WindowBorder.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.250",
+          "green" : "0.250",
+          "red" : "0.250"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.800",
+          "green" : "0.800",
+          "red" : "0.800"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.250",
+          "green" : "0.250",
+          "red" : "0.250"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Views/CodeEditorView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/CodeEditorView.swift
@@ -156,7 +156,7 @@ public struct CodeEditorView: View {
     return CodeEditorView(panel: panel)
         .frame(width: 400, height: 300)
         .padding()
-        .background(Color(white: 0.1))
+        .background(Color.contentBackground)
 }
 
 #Preview("Don't Panel") {
@@ -173,7 +173,7 @@ public struct CodeEditorView: View {
     return CodeEditorView(panel: panel)
         .frame(width: 400, height: 300)
         .padding()
-        .background(Color(white: 0.1))
+        .background(Color.contentBackground)
 }
 
 #Preview("Panel - No Title Bar") {
@@ -183,5 +183,5 @@ public struct CodeEditorView: View {
     return CodeEditorView(panel: panel)
         .frame(width: 400, height: 150)
         .padding()
-        .background(Color(white: 0.1))
+        .background(Color.contentBackground)
 }

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
@@ -32,7 +32,7 @@ public struct ToolBarView: View {
             VStack(spacing: 16) {
                 Text("Code Style")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(Color.secondaryText)
 
                 HStack(spacing: 8) {
                     // Language
@@ -62,7 +62,7 @@ public struct ToolBarView: View {
             VStack(spacing: 16) {
                 Text("Indicator Style")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(Color.secondaryText)
 
                 HStack(spacing: 8) {
                     // Indicator Style
@@ -85,7 +85,7 @@ public struct ToolBarView: View {
         }
         .padding(.horizontal)
         .padding(.vertical, 8)
-        .background(Color(white: 0.15))
+        .background(Color.toolbarBackground)
     }
 
     // MARK: - Language Picker


### PR DESCRIPTION
## Summary
Move all UI colors from hardcoded RGB values to xcassets in the SPM package. The app now supports both light and dark appearances while keeping editor syntax themes unchanged.

## Changes
- Created Colors.xcassets with 14 color sets featuring light/dark variants
- Updated Color+Semantic.swift to load from asset catalog using Bundle.module
- Replaced hardcoded colors in ContentView, ToolBarView, CodeEditorView
- Added three new semantic colors: toolbarBackground, contentBackground, secondaryText
- Updated Package.swift to process Resources folder

## Test Plan
- [x] Dark mode: All UI elements render correctly
- [x] Light mode: Toolbar, content background, title bars adapt to system appearance
- [x] Editor themes remain unchanged regardless of system appearance
- [x] Build succeeds with xcodebuild