### PR TITLE
feat: add shadows and improve spacing for panels

### DIFF
--- a/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
@@ -28,7 +28,7 @@ public struct ContentView: View {
             )
 
             panelsView
-                .padding()
+                .padding(16)
         }
         .background(Color.contentBackground)
         .frame(minHeight: 400)
@@ -42,14 +42,16 @@ public struct ContentView: View {
     private var panelsView: some View {
         Group {
             if layout == .horizontal {
-                HStack(spacing: 16) {
+                HStack(spacing: 24) {
                     panels
                 }
+                .padding(24)
             } else {
                 ScrollView {
-                    VStack(spacing: 16) {
+                    VStack(spacing: 24) {
                         panels
                     }
+                    .padding(24)
                 }
             }
         }
@@ -58,8 +60,10 @@ public struct ContentView: View {
     @ViewBuilder
     private var panels: some View {
         CodeEditorView(panel: viewModel.dontPanel)
+            .shadow(color: .black.opacity(0.3), radius: 12, x: 0, y: 4)
 
         CodeEditorView(panel: viewModel.doPanel)
+            .shadow(color: .black.opacity(0.3), radius: 12, x: 0, y: 4)
     }
 
     // MARK: - Export

--- a/BifcodePackage/Sources/BifcodeFeature/Views/CodeEditorView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/CodeEditorView.swift
@@ -77,10 +77,10 @@ public struct CodeEditorView: View {
             // Traffic light placeholder
             Circle()
                 .fill(Color.editorCloseButton)
-                .frame(width: 12, height: 12)
+                .frame(width: 14, height: 14)
 
             // Title
-            Text(panel.title)
+            Label(panel.title, systemImage: "text.document.fill")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(Color.titleText)
 


### PR DESCRIPTION
Add window-like shadows to code panels with proper padding to prevent clipping. Increase panel spacing for better visual separation and enhance title display with document icon.