### PR TITLE
feat: add view-to-image export with panel title fields

### DIFF
--- a/Bifcode.xcodeproj/project.pbxproj
+++ b/Bifcode.xcodeproj/project.pbxproj
@@ -255,10 +255,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				ONLY_ACTIVE_ARCH = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -294,10 +291,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 15.6;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -306,17 +301,8 @@
 			baseConfigurationReferenceAnchor = 8B90D1BC2DEE373300FBD189 /* Config */;
 			baseConfigurationReferenceRelativePath = Debug.xcconfig;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = icon.icon;
-				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CLANG_ENABLE_OBJC_WEAK = YES;
-				CURRENT_PROJECT_VERSION = 1000;
 				DEAD_CODE_STRIPPING = YES;
-				ENABLE_APP_SANDBOX = YES;
-				ENABLE_USER_SELECTED_FILES = readonly;
-				INFOPLIST_KEY_CFBundleDisplayName = "$(PRODUCT_DISPLAY_NAME)";
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				MARKETING_VERSION = 1.0.0;
-				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -325,17 +311,8 @@
 			baseConfigurationReferenceAnchor = 8B90D1BC2DEE373300FBD189 /* Config */;
 			baseConfigurationReferenceRelativePath = Release.xcconfig;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = icon.icon;
-				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CLANG_ENABLE_OBJC_WEAK = YES;
-				CURRENT_PROJECT_VERSION = 1000;
 				DEAD_CODE_STRIPPING = YES;
-				ENABLE_APP_SANDBOX = YES;
-				ENABLE_USER_SELECTED_FILES = readonly;
-				INFOPLIST_KEY_CFBundleDisplayName = "$(PRODUCT_DISPLAY_NAME)";
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				MARKETING_VERSION = 1.0.0;
-				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
@@ -1,4 +1,6 @@
+import AppKit
 import CodeEditLanguages
+import CodeEditSourceEditor
 import SwiftUI
 
 /// Main content view with Do/Don't code panels
@@ -7,11 +9,31 @@ public struct ContentView: View {
     @State private var selectedLanguage: CodeLanguage = .swift
 
     // MARK: - Settings (via @AppStorage)
-
+    @AppStorage("doTitle") private var doTitleSetting: String = "Do's"
+    @AppStorage("dontTitle") private var dontTitleSetting: String = "Don'ts"
+    
     @AppStorage("windowLayout") private var windowLayoutRaw: String = WindowLayout.horizontal.rawValue
+    @AppStorage("indicatorPosition") private var indicatorPositionRaw: String = IndicatorPosition.topRight.rawValue
+    @AppStorage("indicatorStyle") private var indicatorStyleRaw: String = IndicatorStyle.iconAndText.rawValue
+    @AppStorage("indicatorSize") private var indicatorSize: Double = 48
+    @AppStorage("showTitle") private var showTitle: Bool = true
+    @AppStorage("fontSize") private var fontSize: Double = 14
+    @AppStorage("selectedTheme") private var selectedThemeRaw: String = EditorThemeOption.atomOneDark.rawValue
 
     private var layout: WindowLayout {
         WindowLayout(rawValue: windowLayoutRaw) ?? .horizontal
+    }
+
+    private var indicatorPosition: IndicatorPosition {
+        IndicatorPosition(rawValue: indicatorPositionRaw) ?? .topRight
+    }
+
+    private var indicatorStyle: IndicatorStyle {
+        IndicatorStyle(rawValue: indicatorStyleRaw) ?? .iconAndText
+    }
+
+    private var selectedTheme: EditorThemeOption {
+        EditorThemeOption(rawValue: selectedThemeRaw) ?? .atomOneDark
     }
 
     public init() {}
@@ -20,11 +42,9 @@ public struct ContentView: View {
         VStack(spacing: 0) {
             ToolBarView(
                 selectedLanguage: $selectedLanguage,
-                onExport: {
-                    Task {
-                        await exportImage()
-                    }
-                }
+                doTitleSetting: $doTitleSetting,
+                dontTitleSetting: $dontTitleSetting,
+                onExport: { Task(operation: exportImage) }
             )
 
             panelsView
@@ -34,6 +54,12 @@ public struct ContentView: View {
         .frame(minHeight: 400)
         .onChange(of: selectedLanguage) { _, newValue in
             viewModel.setLanguage(newValue)
+        }
+        .onChange(of: doTitleSetting) { _, newValue in
+            viewModel.update(doTitle: newValue, dontTitle: dontTitleSetting)
+        }
+        .onChange(of: dontTitleSetting) { _, newValue in
+            viewModel.update(doTitle: doTitleSetting, dontTitle: newValue)
         }
     }
 
@@ -66,10 +92,42 @@ public struct ContentView: View {
             .shadow(color: .black.opacity(0.3), radius: 12, x: 0, y: 4)
     }
 
+    // MARK: - Export View
+
+    /// Creates the export view with current settings
+    private var exportView: ExportView {
+        ExportView(
+            doPanel: viewModel.doPanel,
+            dontPanel: viewModel.dontPanel,
+            layout: layout,
+            indicatorPosition: indicatorPosition,
+            indicatorStyle: indicatorStyle,
+            indicatorSize: indicatorSize,
+            showTitle: showTitle,
+            fontSize: fontSize,
+            theme: selectedTheme.editorTheme
+        )
+    }
+
     // MARK: - Export
 
+    @MainActor
     private func exportImage() async {
-        // TODO: Implement export using ImageRenderer
+        let renderer = ImageRenderer(content: exportView)
+        // Use 2x scale for Retina quality
+        renderer.scale = 2.0
+
+        guard let nsImage = renderer.nsImage else {
+            // TODO: Show error alert
+            return
+        }
+
+        do {
+            try await viewModel.saveImage(nsImage)
+        } catch {
+            // TODO: Show error alert
+            print("Export failed: \(error.localizedDescription)")
+        }
     }
 }
 

--- a/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
@@ -55,6 +55,9 @@ public struct ContentView: View {
         .onChange(of: selectedLanguage) { _, newValue in
             viewModel.setLanguage(newValue)
         }
+        .onAppear() {
+            viewModel.update(doTitle: doTitleSetting, dontTitle: dontTitleSetting)
+        }
         .onChange(of: doTitleSetting) { _, newValue in
             viewModel.update(doTitle: newValue, dontTitle: dontTitleSetting)
         }

--- a/BifcodePackage/Sources/BifcodeFeature/Models/CodePanel.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Models/CodePanel.swift
@@ -24,7 +24,7 @@ public final class CodePanel: Identifiable {
     /// Editor state for cursor position, scroll, etc.
     public var editorState: SourceEditorState
 
-    public init(type: PanelType, title: String, language: CodeLanguage = .swift) {
+    public init(type: PanelType, title: String = "", language: CodeLanguage = .swift) {
         self.type = type
         self.title = title
         self.language = language

--- a/BifcodePackage/Sources/BifcodeFeature/ViewModels/AppViewModel.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/ViewModels/AppViewModel.swift
@@ -16,16 +16,10 @@ public final class AppViewModel {
     @ObservationIgnored
     @AppStorage("saveLocation") private var saveLocationPath: String = ""
 
-    @ObservationIgnored
-    @AppStorage("doTitle") private var doTitleSetting: String = "Do's"
-
-    @ObservationIgnored
-    @AppStorage("dontTitle") private var dontTitleSetting: String = "Don'ts"
-
     /// Computed URL for save location, defaults to Desktop
     public var saveLocation: URL {
         if saveLocationPath.isEmpty {
-            return FileManager.default.urls(for: .desktopDirectory, in: .userDomainMask).first!
+            return FileManager.default.urls(for: .picturesDirectory, in: .userDomainMask).first!
         }
         return URL(fileURLWithPath: saveLocationPath)
     }
@@ -34,12 +28,8 @@ public final class AppViewModel {
 
     public init() {
         // Read titles from UserDefaults directly for initialization
-        let defaults = UserDefaults.standard
-        let doTitle = defaults.string(forKey: "doTitle") ?? "Do's"
-        let dontTitle = defaults.string(forKey: "dontTitle") ?? "Don'ts"
-
-        doPanel = CodePanel(type: .doPanel, title: doTitle)
-        dontPanel = CodePanel(type: .dontPanel, title: dontTitle)
+        doPanel = CodePanel(type: .doPanel)
+        dontPanel = CodePanel(type: .dontPanel)
     }
 
     // MARK: - Language Management
@@ -49,13 +39,14 @@ public final class AppViewModel {
         doPanel.language = language
         dontPanel.language = language
     }
+    
+    /// Updates the language for both panels
+    public func update(doTitle: String, dontTitle: String) {
+        doPanel.title = doTitle
+        dontPanel.title = dontTitle
+    }
 
     // MARK: - Export
-
-    public func exportImage() async -> NSImage? {
-        // TODO: Implement image export
-        nil
-    }
 
     public func saveImage(_ image: NSImage) async throws {
         let filename = "bifcode-\(Date().timeIntervalSince1970).png"

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ExportPanelView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ExportPanelView.swift
@@ -1,0 +1,153 @@
+import AppKit
+import CodeEditLanguages
+import CodeEditSourceEditor
+import SwiftUI
+
+/// Static code panel view optimized for ImageRenderer export
+/// Uses Text instead of SourceEditor for pure SwiftUI rendering
+struct ExportPanelView: View {
+    let panel: CodePanel
+    let indicatorPosition: IndicatorPosition
+    let indicatorStyle: IndicatorStyle
+    let indicatorSize: CGFloat
+    let showTitle: Bool
+    let fontSize: CGFloat
+    let theme: EditorTheme
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if showTitle {
+                titleBar
+            }
+
+            editorArea
+        }
+        .background(Color(nsColor: theme.background))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.windowBorder, lineWidth: 1)
+        )
+    }
+
+    // MARK: - Title Bar
+
+    private var titleBar: some View {
+        HStack(spacing: 14) {
+            // Traffic light placeholder
+            Circle()
+                .fill(Color.editorCloseButton)
+                .frame(width: 14, height: 14)
+
+            // Title
+            Label(panel.title, systemImage: "text.document.fill")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Color.titleText)
+
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Color.titleBarBackground)
+    }
+
+    // MARK: - Editor Area
+
+    private var editorArea: some View {
+        ZStack(alignment: indicatorAlignment) {
+            // Static code display
+            codeContent
+                .padding(10)
+
+            // Indicator badge
+            IndicatorBadgeView(
+                type: panel.type,
+                style: indicatorStyle,
+                size: indicatorSize
+            )
+            .padding(12)
+        }
+    }
+
+    private var codeContent: some View {
+        HStack(alignment: .top, spacing: 0) {
+            // Line numbers
+            lineNumbers
+                .padding(.trailing, 8)
+
+            // Code text with syntax highlighting colors from theme
+            Text(panel.code)
+                .font(.system(size: fontSize, design: .monospaced))
+                .foregroundStyle(Color(nsColor: theme.text.color))
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var lineNumbers: some View {
+        let lines = panel.code.components(separatedBy: "\n")
+        let maxDigits = String(lines.count).count
+
+        return VStack(alignment: .trailing, spacing: 0) {
+            ForEach(1 ... max(lines.count, 1), id: \.self) { number in
+                Text(String(format: "%\(maxDigits)d", number))
+                    .font(.system(size: fontSize, design: .monospaced))
+                    .foregroundStyle(Color(nsColor: theme.invisibles.color))
+            }
+        }
+    }
+
+    private var indicatorAlignment: Alignment {
+        indicatorPosition == .topRight ? .topTrailing : .bottomTrailing
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Export Panel - Do") {
+    let panel = CodePanel(type: .doPanel, title: "Do's")
+    panel.code = """
+    // Use descriptive variable names
+    let userName = "Alice"
+    let isLoggedIn = true
+    """
+
+    return ExportPanelView(
+        panel: panel,
+        indicatorPosition: .topRight,
+        indicatorStyle: .iconAndText,
+        indicatorSize: 48,
+        showTitle: true,
+        fontSize: 14,
+        theme: .atomOneDark
+    )
+    .frame(width: 400)
+    .padding()
+    .background(Color.contentBackground)
+}
+
+#Preview("Export Panel - Don't") {
+    let panel = CodePanel(type: .dontPanel, title: "Don'ts")
+    panel.code = """
+    // Avoid single-letter variables
+    let x = "Bob"
+    let y = false
+    """
+
+    return ExportPanelView(
+        panel: panel,
+        indicatorPosition: .topRight,
+        indicatorStyle: .iconAndText,
+        indicatorSize: 48,
+        showTitle: true,
+        fontSize: 14,
+        theme: .atomOneDark
+    )
+    .frame(width: 400)
+    .padding()
+    .background(Color.contentBackground)
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ExportView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ExportView.swift
@@ -1,0 +1,114 @@
+import AppKit
+import CodeEditSourceEditor
+import SwiftUI
+
+/// Combined export view with both panels for ImageRenderer
+/// This view is used exclusively for generating the export image
+struct ExportView: View {
+    let doPanel: CodePanel
+    let dontPanel: CodePanel
+    let layout: WindowLayout
+    let indicatorPosition: IndicatorPosition
+    let indicatorStyle: IndicatorStyle
+    let indicatorSize: CGFloat
+    let showTitle: Bool
+    let fontSize: CGFloat
+    let theme: EditorTheme
+
+    var body: some View {
+        Group {
+            if layout == .horizontal {
+                HStack(spacing: 24) {
+                    panels
+                }
+            } else {
+                VStack(spacing: 24) {
+                    panels
+                }
+            }
+        }
+        .padding(24)
+        .background(Color.contentBackground)
+    }
+
+    @ViewBuilder
+    private var panels: some View {
+        ExportPanelView(
+            panel: dontPanel,
+            indicatorPosition: indicatorPosition,
+            indicatorStyle: indicatorStyle,
+            indicatorSize: indicatorSize,
+            showTitle: showTitle,
+            fontSize: fontSize,
+            theme: theme
+        )
+        .shadow(color: .black.opacity(0.3), radius: 12, x: 0, y: 4)
+
+        ExportPanelView(
+            panel: doPanel,
+            indicatorPosition: indicatorPosition,
+            indicatorStyle: indicatorStyle,
+            indicatorSize: indicatorSize,
+            showTitle: showTitle,
+            fontSize: fontSize,
+            theme: theme
+        )
+        .shadow(color: .black.opacity(0.3), radius: 12, x: 0, y: 4)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Export View - Horizontal") {
+    let doPanel = CodePanel(type: .doPanel, title: "Do's")
+    doPanel.code = """
+    // Use descriptive names
+    let userName = "Alice"
+    """
+
+    let dontPanel = CodePanel(type: .dontPanel, title: "Don'ts")
+    dontPanel.code = """
+    // Avoid short names
+    let x = "Bob"
+    """
+
+    return ExportView(
+        doPanel: doPanel,
+        dontPanel: dontPanel,
+        layout: .horizontal,
+        indicatorPosition: .topRight,
+        indicatorStyle: .iconAndText,
+        indicatorSize: 48,
+        showTitle: true,
+        fontSize: 14,
+        theme: .atomOneDark
+    )
+    .frame(width: 800, height: 300)
+}
+
+#Preview("Export View - Vertical") {
+    let doPanel = CodePanel(type: .doPanel, title: "Do's")
+    doPanel.code = """
+    // Use descriptive names
+    let userName = "Alice"
+    """
+
+    let dontPanel = CodePanel(type: .dontPanel, title: "Don'ts")
+    dontPanel.code = """
+    // Avoid short names
+    let x = "Bob"
+    """
+
+    return ExportView(
+        doPanel: doPanel,
+        dontPanel: dontPanel,
+        layout: .vertical,
+        indicatorPosition: .topRight,
+        indicatorStyle: .iconAndText,
+        indicatorSize: 48,
+        showTitle: true,
+        fontSize: 14,
+        theme: .atomOneDark
+    )
+    .frame(width: 500, height: 500)
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
@@ -13,6 +13,8 @@ public struct ToolBarView: View {
     @AppStorage("fontSize") private var fontSize: Double = 14
     @AppStorage("selectedTheme") private var selectedThemeRaw: String = EditorThemeOption.atomOneDark.rawValue
 
+    @Binding private var doTitleSetting: String
+    @Binding private var dontTitleSetting: String
     // MARK: - Bindings
 
     @Binding var selectedLanguage: CodeLanguage
@@ -20,8 +22,13 @@ public struct ToolBarView: View {
 
     // MARK: - Initialization
 
-    public init(selectedLanguage: Binding<CodeLanguage>, onExport: @escaping () -> Void) {
+    public init(selectedLanguage: Binding<CodeLanguage>,
+                doTitleSetting: Binding<String>,
+                dontTitleSetting: Binding<String>,
+                onExport: @escaping () -> Void) {
         _selectedLanguage = selectedLanguage
+        _doTitleSetting = doTitleSetting
+        _dontTitleSetting = dontTitleSetting
         self.onExport = onExport
     }
 
@@ -205,6 +212,8 @@ public struct ToolBarView: View {
 #Preview("ToolBarView") {
     ToolBarView(
         selectedLanguage: .constant(.swift),
+        doTitleSetting: .constant("1"),
+        dontTitleSetting: .constant("2"),
         onExport: {}
     )
 }

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
@@ -15,6 +15,7 @@ public struct ToolBarView: View {
 
     @Binding private var doTitleSetting: String
     @Binding private var dontTitleSetting: String
+
     // MARK: - Bindings
 
     @Binding var selectedLanguage: CodeLanguage
@@ -25,7 +26,8 @@ public struct ToolBarView: View {
     public init(selectedLanguage: Binding<CodeLanguage>,
                 doTitleSetting: Binding<String>,
                 dontTitleSetting: Binding<String>,
-                onExport: @escaping () -> Void) {
+                onExport: @escaping () -> Void)
+    {
         _selectedLanguage = selectedLanguage
         _doTitleSetting = doTitleSetting
         _dontTitleSetting = dontTitleSetting
@@ -35,7 +37,7 @@ public struct ToolBarView: View {
     // MARK: - Body
 
     public var body: some View {
-        HStack(spacing: 16) {
+        HStack(alignment: .top, spacing: 16) {
             VStack(spacing: 16) {
                 Text("Code Style")
                     .font(.caption)
@@ -57,12 +59,25 @@ public struct ToolBarView: View {
                     // Layout
                     layoutToggle
                 }
-                .layoutPriority(3)
+                .fixedSize()
 
                 // Font Size
                 fontSizeControl
-                    .layoutPriority(2)
+                
+                VStack(spacing: 16) {
+                    Text("Panel Titles")
+                        .font(.caption)
+                        .foregroundStyle(Color.secondaryText)
+
+                    HStack(spacing: 8) {
+                        doTitleField
+                        dontTitleField
+                    }
+                }
+                .frame(maxWidth: .infinity)
             }
+            .fixedSize()
+            .layoutPriority(1)
 
             Divider().frame(height: 48)
 
@@ -83,7 +98,7 @@ public struct ToolBarView: View {
                 indicatorSizeControl
             }
 
-            Divider().frame(height: 20)
+            Divider().frame(height: 48)
 
             Spacer(minLength: 0)
 
@@ -184,14 +199,28 @@ public struct ToolBarView: View {
 
     private var fontSizeControl: some View {
         HStack(spacing: 4) {
-            Slider(value: $fontSize, in: 10 ... 24, step: 1)
-                .frame(width: 130)
+            Slider(value: $fontSize, in: 10 ... 34, step: 1)
+                .frame(maxWidth: .infinity)
 
             Text("\(Int(fontSize))")
                 .font(.body)
                 .monospacedDigit()
-                .frame(width: 24, alignment: .trailing)
+                .padding(.leading, 8)
+                .fixedSize()
         }
+        .padding(.horizontal, 24)
+    }
+
+    // MARK: - Title Fields
+
+    private var doTitleField: some View {
+        TextField("Do Title", text: $doTitleSetting)
+            .textFieldStyle(.roundedBorder)
+    }
+
+    private var dontTitleField: some View {
+        TextField("Don't Title", text: $dontTitleSetting)
+            .textFieldStyle(.roundedBorder)
     }
 
     // MARK: - Export Button

--- a/Config/Bifcode.entitlements
+++ b/Config/Bifcode.entitlements
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict/>
-</plist>

--- a/Config/Debug.xcconfig
+++ b/Config/Debug.xcconfig
@@ -6,3 +6,5 @@
 
 // No additional debug-specific overrides needed
 // All debug settings use Xcode project defaults
+
+ONLY_ACTIVE_ARCH = YES

--- a/Config/Shared.xcconfig
+++ b/Config/Shared.xcconfig
@@ -9,8 +9,11 @@
 PRODUCT_NAME = Bifcode
 PRODUCT_DISPLAY_NAME = Bifcode
 PRODUCT_BUNDLE_IDENTIFIER = com.igrsoft.bifcode
-MARKETING_VERSION = 1.0
-CURRENT_PROJECT_VERSION = 1
+MARKETING_VERSION = 1.0.0
+CURRENT_PROJECT_VERSION = 1000
+INFOPLIST_KEY_CFBundleDisplayName = $(PRODUCT_DISPLAY_NAME)
+INFOPLIST_KEY_LSApplicationCategoryType = public.app-category.developer-tools
+
 
 // ==========================================
 // Platform Configuration
@@ -22,8 +25,17 @@ MACOSX_DEPLOYMENT_TARGET = 15.0
 // ==========================================
 GENERATE_INFOPLIST_FILE = YES
 
-// ==========================================
-// Entitlements
-// ==========================================
-// AI agents can modify Config/Bifcode.entitlements to add capabilities
-CODE_SIGN_ENTITLEMENTS = Config/Bifcode.entitlements
+CODE_SIGN_IDENTITY = Apple Development
+CODE_SIGN_STYLE = Automatic
+DEVELOPMENT_TEAM = DMP42GVPJ3
+PROVISIONING_PROFILE_SPECIFIER =
+
+ENABLE_APP_SANDBOX = YES
+ENABLE_FILE_ACCESS_PICTURE_FOLDER = readwrite
+ENABLE_USER_SELECTED_FILES = readwrite
+
+ASSETCATALOG_COMPILER_APPICON_NAME = icon
+ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES
+
+SWIFT_VERSION = 6.2
+


### PR DESCRIPTION
## Summary

- Implements view-to-image export using `ImageRenderer` with 2x Retina quality
- Adds two TextFields to toolbar for editing Do and Don't panel titles
- Creates export-specific views (`ExportView`, `ExportPanelView`) for reliable SwiftUI rendering

## Changes

- New `ExportPanelView` for static code display (pure SwiftUI, no NSView wrapper)
- New `ExportView` combining both panels with layout and settings
- `ContentView.exportImage()` uses `ImageRenderer` to render and save PNG
- Panel titles persisted via `@AppStorage` and synced on change
- Xcode project configuration updates

## Test plan

- Export button renders both panels to image with correct layout
- Indicator badges and title bars appear in export
- Panel titles can be edited and persist
- Font size and theme settings applied to export