### PR TITLE
feat: add customizable indicator icons and labels

### DIFF
--- a/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
@@ -19,7 +19,11 @@ public struct ContentView: View {
 
     @AppStorage("doTitle") private var doTitleSetting: String = "Do's"
     @AppStorage("dontTitle") private var dontTitleSetting: String = "Don'ts"
-    
+    @AppStorage("doIndicatorIcon") private var doIndicatorIcon: String = "checkmark"
+    @AppStorage("dontIndicatorIcon") private var dontIndicatorIcon: String = "xmark"
+    @AppStorage("doIndicatorLabel") private var doIndicatorLabel: String = "Do's"
+    @AppStorage("dontIndicatorLabel") private var dontIndicatorLabel: String = "Don'ts"
+
     @AppStorage("windowLayout") private var windowLayoutRaw: String = WindowLayout.horizontal.rawValue
     @AppStorage("indicatorPosition") private var indicatorPositionRaw: String = IndicatorPosition.topRight.rawValue
     @AppStorage("indicatorStyle") private var indicatorStyleRaw: String = IndicatorStyle.iconAndText.rawValue
@@ -114,6 +118,10 @@ public struct ContentView: View {
             indicatorPosition: indicatorPosition,
             indicatorStyle: indicatorStyle,
             indicatorSize: indicatorSize,
+            doIndicatorIcon: doIndicatorIcon,
+            dontIndicatorIcon: dontIndicatorIcon,
+            doIndicatorLabel: doIndicatorLabel,
+            dontIndicatorLabel: dontIndicatorLabel,
             showTitle: showTitle,
             fontSize: fontSize,
             theme: selectedTheme.editorTheme

--- a/BifcodePackage/Sources/BifcodeFeature/Models/SettingsTypes.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Models/SettingsTypes.swift
@@ -37,6 +37,35 @@ public enum IndicatorStyle: String, CaseIterable, Sendable {
     }
 }
 
+/// Curated SF Symbol options for indicators
+public enum IndicatorIcon: String, CaseIterable, Sendable {
+    // Positive indicators
+    case checkmark
+    case checkmarkCircle = "checkmark.circle"
+    case checkmarkSquare = "checkmark.square"
+    case thumbsUp = "hand.thumbsup"
+    case star = "star.fill"
+
+    // Negative indicators
+    case xmark
+    case xmarkCircle = "xmark.circle"
+    case xmarkSquare = "xmark.square"
+    case thumbsDown = "hand.thumbsdown"
+    case warning = "exclamationmark.triangle"
+
+    public var systemName: String { rawValue }
+
+    /// Icons suitable for "Do" indicators
+    public static var positiveIcons: [IndicatorIcon] {
+        [.checkmark, .checkmarkCircle, .checkmarkSquare, .thumbsUp, .star]
+    }
+
+    /// Icons suitable for "Don't" indicators
+    public static var negativeIcons: [IndicatorIcon] {
+        [.xmark, .xmarkCircle, .xmarkSquare, .thumbsDown, .warning]
+    }
+}
+
 /// Window layout options
 public enum WindowLayout: String, CaseIterable, Sendable {
     case horizontal

--- a/BifcodePackage/Sources/BifcodeFeature/Views/CodeEditorView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/CodeEditorView.swift
@@ -20,6 +20,10 @@ public struct CodeEditorView: View {
     @AppStorage("indicatorPosition") private var indicatorPositionRaw: String = IndicatorPosition.topRight.rawValue
     @AppStorage("indicatorStyle") private var indicatorStyleRaw: String = IndicatorStyle.iconAndText.rawValue
     @AppStorage("indicatorSize") private var indicatorSize: Double = 48
+    @AppStorage("doIndicatorIcon") private var doIndicatorIcon: String = "checkmark"
+    @AppStorage("dontIndicatorIcon") private var dontIndicatorIcon: String = "xmark"
+    @AppStorage("doIndicatorLabel") private var doIndicatorLabel: String = "Do's"
+    @AppStorage("dontIndicatorLabel") private var dontIndicatorLabel: String = "Don'ts"
     @AppStorage("showTitle") private var showTitle: Bool = true
     @AppStorage("fontSize") private var fontSize: Double = 14
     @AppStorage("selectedTheme") private var selectedThemeRaw: String = EditorThemeOption.atomOneDark.rawValue
@@ -109,7 +113,9 @@ public struct CodeEditorView: View {
             IndicatorBadgeView(
                 type: panel.type,
                 style: indicatorStyle,
-                size: indicatorSize
+                size: indicatorSize,
+                iconName: panel.type == .doPanel ? doIndicatorIcon : dontIndicatorIcon,
+                label: panel.type == .doPanel ? doIndicatorLabel : dontIndicatorLabel
             )
             .padding(12)
         }

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ExportPanelView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ExportPanelView.swift
@@ -17,6 +17,8 @@ struct ExportPanelView: View {
     let indicatorPosition: IndicatorPosition
     let indicatorStyle: IndicatorStyle
     let indicatorSize: CGFloat
+    let indicatorIconName: String
+    let indicatorLabel: String
     let showTitle: Bool
     let fontSize: CGFloat
     let theme: EditorTheme
@@ -72,7 +74,9 @@ struct ExportPanelView: View {
             IndicatorBadgeView(
                 type: panel.type,
                 style: indicatorStyle,
-                size: indicatorSize
+                size: indicatorSize,
+                iconName: indicatorIconName,
+                label: indicatorLabel
             )
             .padding(12)
         }
@@ -128,6 +132,8 @@ struct ExportPanelView: View {
         indicatorPosition: .topRight,
         indicatorStyle: .iconAndText,
         indicatorSize: 48,
+        indicatorIconName: "checkmark",
+        indicatorLabel: "Do's",
         showTitle: true,
         fontSize: 14,
         theme: .atomOneDark
@@ -150,6 +156,8 @@ struct ExportPanelView: View {
         indicatorPosition: .topRight,
         indicatorStyle: .iconAndText,
         indicatorSize: 48,
+        indicatorIconName: "xmark",
+        indicatorLabel: "Don'ts",
         showTitle: true,
         fontSize: 14,
         theme: .atomOneDark

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ExportView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ExportView.swift
@@ -18,6 +18,10 @@ struct ExportView: View {
     let indicatorPosition: IndicatorPosition
     let indicatorStyle: IndicatorStyle
     let indicatorSize: CGFloat
+    let doIndicatorIcon: String
+    let dontIndicatorIcon: String
+    let doIndicatorLabel: String
+    let dontIndicatorLabel: String
     let showTitle: Bool
     let fontSize: CGFloat
     let theme: EditorTheme
@@ -45,6 +49,8 @@ struct ExportView: View {
             indicatorPosition: indicatorPosition,
             indicatorStyle: indicatorStyle,
             indicatorSize: indicatorSize,
+            indicatorIconName: dontIndicatorIcon,
+            indicatorLabel: dontIndicatorLabel,
             showTitle: showTitle,
             fontSize: fontSize,
             theme: theme
@@ -56,6 +62,8 @@ struct ExportView: View {
             indicatorPosition: indicatorPosition,
             indicatorStyle: indicatorStyle,
             indicatorSize: indicatorSize,
+            indicatorIconName: doIndicatorIcon,
+            indicatorLabel: doIndicatorLabel,
             showTitle: showTitle,
             fontSize: fontSize,
             theme: theme
@@ -86,6 +94,10 @@ struct ExportView: View {
         indicatorPosition: .topRight,
         indicatorStyle: .iconAndText,
         indicatorSize: 48,
+        doIndicatorIcon: "checkmark",
+        dontIndicatorIcon: "xmark",
+        doIndicatorLabel: "Do's",
+        dontIndicatorLabel: "Don'ts",
         showTitle: true,
         fontSize: 14,
         theme: .atomOneDark
@@ -113,6 +125,10 @@ struct ExportView: View {
         indicatorPosition: .topRight,
         indicatorStyle: .iconAndText,
         indicatorSize: 48,
+        doIndicatorIcon: "checkmark",
+        dontIndicatorIcon: "xmark",
+        doIndicatorLabel: "Do's",
+        dontIndicatorLabel: "Don'ts",
         showTitle: true,
         fontSize: 14,
         theme: .atomOneDark

--- a/BifcodePackage/Sources/BifcodeFeature/Views/IndicatorBadgeView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/IndicatorBadgeView.swift
@@ -12,23 +12,25 @@ public struct IndicatorBadgeView: View {
     let type: PanelType
     let style: IndicatorStyle
     let size: CGFloat
+    let iconName: String
+    let label: String
 
-    public init(type: PanelType, style: IndicatorStyle, size: CGFloat) {
+    public init(
+        type: PanelType,
+        style: IndicatorStyle,
+        size: CGFloat,
+        iconName: String? = nil,
+        label: String? = nil
+    ) {
         self.type = type
         self.style = style
         self.size = size
+        self.iconName = iconName ?? (type == .doPanel ? "checkmark" : "xmark")
+        self.label = label ?? (type == .doPanel ? "Do's" : "Don'ts")
     }
 
     private var color: Color {
         type == .doPanel ? .indicatorDo : .indicatorDont
-    }
-
-    private var iconName: String {
-        type == .doPanel ? "checkmark" : "xmark"
-    }
-
-    private var label: String {
-        type == .doPanel ? "Do's" : "Don'ts"
     }
 
     public var body: some View {
@@ -44,15 +46,10 @@ public struct IndicatorBadgeView: View {
     }
 
     private var iconView: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: size * 0.15)
-                .stroke(color, lineWidth: 3)
-                .frame(width: size, height: size)
-
-            Image(systemName: iconName)
-                .font(.system(size: size * 0.5, weight: .bold))
-                .foregroundStyle(color)
-        }
+        Image(systemName: iconName)
+            .font(.system(size: size * 0.6, weight: .bold))
+            .foregroundStyle(color)
+            .frame(width: size, height: size)
     }
 
     private var textView: some View {

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
@@ -17,10 +17,19 @@ public struct ToolBarView: View {
     @AppStorage("indicatorStyle") private var indicatorStyle: String = IndicatorStyle.iconAndText.rawValue
     @AppStorage("indicatorPosition") private var indicatorPosition: String = IndicatorPosition.topRight.rawValue
     @AppStorage("indicatorSize") private var indicatorSize: Double = 48
+    @AppStorage("doIndicatorIcon") private var doIndicatorIcon: String = "checkmark"
+    @AppStorage("dontIndicatorIcon") private var dontIndicatorIcon: String = "xmark"
+    @AppStorage("doIndicatorLabel") private var doIndicatorLabel: String = "Do's"
+    @AppStorage("dontIndicatorLabel") private var dontIndicatorLabel: String = "Don'ts"
     @AppStorage("fontSize") private var fontSize: Double = 14
     @AppStorage("selectedTheme") private var selectedThemeRaw: String = EditorThemeOption.atomOneDark.rawValue
 
     @AppStorage("saveLocation") private var saveLocationPath: String = ""
+
+    /// Current indicator style for disable logic
+    private var currentIndicatorStyle: IndicatorStyle {
+        IndicatorStyle(rawValue: indicatorStyle) ?? .iconAndText
+    }
     
     @Binding private var doTitleSetting: String
     @Binding private var dontTitleSetting: String
@@ -97,11 +106,12 @@ public struct ToolBarView: View {
                     .font(.caption)
                     .foregroundStyle(Color.secondaryText)
                 
-                HStack(spacing: 8) {
+                HStack(spacing: 16) {
                     doTitleField
                     dontTitleField
                 }
             }
+            .padding(.top, 11)
             .frame(maxWidth: .infinity)
         }
         .fixedSize()
@@ -114,19 +124,41 @@ public struct ToolBarView: View {
             Text("Indicator Style")
                 .font(.caption)
                 .foregroundStyle(Color.secondaryText)
-            
+
             HStack(spacing: 8) {
                 // Indicator Style
                 indicatorStylePicker
-                
+
                 // Indicator Position
                 indicatorPositionPicker
             }
             .fixedSize()
+            .layoutPriority(1)
             
             // Indicator Size
             indicatorSizeControl
+            
+            // Icon Pickers
+            HStack(spacing: 16) {
+                doIconPicker
+                    .frame(maxWidth: .infinity)
+                Spacer()
+                dontIconPicker
+                    .padding(.leading, 8)
+            }
+            .frame(maxWidth: .infinity)
+
+            // Indicator Labels
+            HStack(spacing: 8) {
+                doIndicatorLabelField
+                    .padding(.horizontal, 8)
+                    .frame(maxWidth: .infinity)
+                dontIndicatorLabelField
+                    .frame(maxWidth: .infinity)
+            }
+            .frame(maxWidth: .infinity)
         }
+        .fixedSize()
     }
     
     // MARK: - Language Picker
@@ -204,6 +236,56 @@ public struct ToolBarView: View {
         .fixedSize()
     }
 
+    // MARK: - Icon Pickers
+
+    private var doIconPicker: some View {
+        Picker("Do", selection: $doIndicatorIcon) {
+            ForEach(IndicatorIcon.positiveIcons, id: \.rawValue) { icon in
+                Image(systemName: icon.systemName)
+                    .tag(icon.systemName)
+            }
+        }
+        .pickerStyle(.menu)
+        .fixedSize()
+        .disabled(currentIndicatorStyle == .textOnly)
+    }
+
+    private var dontIconPicker: some View {
+        Picker("Don't", selection: $dontIndicatorIcon) {
+            ForEach(IndicatorIcon.negativeIcons, id: \.rawValue) { icon in
+                Image(systemName: icon.systemName)
+                    .tag(icon.systemName)
+            }
+        }
+        .pickerStyle(.menu)
+        .fixedSize()
+        .disabled(currentIndicatorStyle == .textOnly)
+    }
+
+    // MARK: - Indicator Label Fields
+
+    private var doIndicatorLabelField: some View {
+        TextField("Do Label", text: $doIndicatorLabel)
+            .textFieldStyle(.roundedBorder)
+            .disabled(currentIndicatorStyle == .iconOnly)
+            .onChange(of: doIndicatorLabel) { _, newValue in
+                if newValue.count > 10 {
+                    doIndicatorLabel = String(newValue.prefix(10))
+                }
+            }
+    }
+
+    private var dontIndicatorLabelField: some View {
+        TextField("Don't Label", text: $dontIndicatorLabel)
+            .textFieldStyle(.roundedBorder)
+            .disabled(currentIndicatorStyle == .iconOnly)
+            .onChange(of: dontIndicatorLabel) { _, newValue in
+                if newValue.count > 10 {
+                    dontIndicatorLabel = String(newValue.prefix(10))
+                }
+            }
+    }
+
     // MARK: - Indicator Size
 
     private var indicatorSizeControl: some View {
@@ -241,11 +323,23 @@ public struct ToolBarView: View {
     private var doTitleField: some View {
         TextField("Do Title", text: $doTitleSetting)
             .textFieldStyle(.roundedBorder)
+            .frame(width: 150)
+            .onChange(of: doTitleSetting) { _, newValue in
+                if newValue.count > 70 {
+                    doTitleSetting = String(newValue.prefix(70))
+                }
+            }
     }
 
     private var dontTitleField: some View {
         TextField("Don't Title", text: $dontTitleSetting)
             .textFieldStyle(.roundedBorder)
+            .frame(width: 150)
+            .onChange(of: dontTitleSetting) { _, newValue in
+                if newValue.count > 70 {
+                    dontTitleSetting = String(newValue.prefix(70))
+                }
+            }
     }
 
     // MARK: - Export Button

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
@@ -20,6 +20,8 @@ public struct ToolBarView: View {
     @AppStorage("fontSize") private var fontSize: Double = 14
     @AppStorage("selectedTheme") private var selectedThemeRaw: String = EditorThemeOption.atomOneDark.rawValue
 
+    @AppStorage("saveLocation") private var saveLocationPath: String = ""
+    
     @Binding private var doTitleSetting: String
     @Binding private var dontTitleSetting: String
 
@@ -42,70 +44,18 @@ public struct ToolBarView: View {
     }
 
     // MARK: - Body
-
+    
     public var body: some View {
-        HStack(alignment: .top, spacing: 16) {
-            VStack(spacing: 16) {
-                Text("Code Style")
-                    .font(.caption)
-                    .foregroundStyle(Color.secondaryText)
+        HStack(alignment: .top, spacing: 8) {
+            codeSettingsView()
+                .padding(.trailing, 8)
 
-                HStack(spacing: 8) {
-                    // Language
-                    languagePicker
+            Divider().frame(height: 150)
 
-                    Divider().frame(width: 1, height: 20)
-                        .padding(.leading, 8)
-
-                    // Theme
-                    themePicker
-
-                    Divider().frame(width: 1, height: 20)
-                        .padding(.leading, 8)
-
-                    // Layout
-                    layoutToggle
-                }
-                .fixedSize()
-
-                // Font Size
-                fontSizeControl
-                
-                VStack(spacing: 16) {
-                    Text("Panel Titles")
-                        .font(.caption)
-                        .foregroundStyle(Color.secondaryText)
-
-                    HStack(spacing: 8) {
-                        doTitleField
-                        dontTitleField
-                    }
-                }
-                .frame(maxWidth: .infinity)
-            }
-            .fixedSize()
-            .layoutPriority(1)
-
-            Divider().frame(height: 48)
-
-            VStack(spacing: 16) {
-                Text("Indicator Style")
-                    .font(.caption)
-                    .foregroundStyle(Color.secondaryText)
-
-                HStack(spacing: 8) {
-                    // Indicator Style
-                    indicatorStylePicker
-
-                    // Indicator Position
-                    indicatorPositionPicker
-                }
-
-                // Indicator Size
-                indicatorSizeControl
-            }
-
-            Divider().frame(height: 48)
+            indicatorSettingsView()
+                .padding(.trailing, 8)
+            
+            Divider().frame(height: 150)
 
             Spacer(minLength: 0)
 
@@ -117,6 +67,68 @@ public struct ToolBarView: View {
         .background(Color.toolbarBackground)
     }
 
+    @ViewBuilder
+    private func codeSettingsView() -> some View {
+        VStack(spacing: 16) {
+            Text("Code Style")
+                .font(.caption)
+                .foregroundStyle(Color.secondaryText)
+            
+            HStack(spacing: 8) {
+                // Language
+                languagePicker
+                
+                // Theme
+                themePicker
+                
+                Divider().frame(width: 1, height: 20)
+                    .padding(.leading, 8)
+                
+                // Layout
+                layoutToggle
+            }
+            .fixedSize()
+            
+            // Font Size
+            fontSizeControl
+            
+            VStack(spacing: 16) {
+                Text("Panel Titles")
+                    .font(.caption)
+                    .foregroundStyle(Color.secondaryText)
+                
+                HStack(spacing: 8) {
+                    doTitleField
+                    dontTitleField
+                }
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .fixedSize()
+        .layoutPriority(1)
+    }
+    
+    @ViewBuilder
+    private func indicatorSettingsView() -> some View {
+        VStack(spacing: 16) {
+            Text("Indicator Style")
+                .font(.caption)
+                .foregroundStyle(Color.secondaryText)
+            
+            HStack(spacing: 8) {
+                // Indicator Style
+                indicatorStylePicker
+                
+                // Indicator Position
+                indicatorPositionPicker
+            }
+            .fixedSize()
+            
+            // Indicator Size
+            indicatorSizeControl
+        }
+    }
+    
     // MARK: - Language Picker
 
     private var languagePicker: some View {
@@ -126,7 +138,8 @@ public struct ToolBarView: View {
                     Text(lang.id.rawValue.capitalized).tag(lang)
                 }
             }
-            .frame(width: 100)
+            .pickerStyle(.menu)
+            .fixedSize()
         }
     }
 
@@ -147,7 +160,8 @@ public struct ToolBarView: View {
                 Text(theme.label).tag(theme.rawValue)
             }
         }
-        .frame(width: 140)
+        .pickerStyle(.menu)
+        .fixedSize()
     }
 
     // MARK: - Layout Toggle
@@ -171,7 +185,8 @@ public struct ToolBarView: View {
                 Text(style.label).tag(style)
             }
         }
-        .frame(width: 120)
+        .pickerStyle(.menu)
+        .fixedSize()
     }
 
     // MARK: - Indicator Position
@@ -185,7 +200,8 @@ public struct ToolBarView: View {
                 Text(position.label).tag(position)
             }
         }
-        .frame(width: 120)
+        .pickerStyle(.menu)
+        .fixedSize()
     }
 
     // MARK: - Indicator Size
@@ -193,13 +209,15 @@ public struct ToolBarView: View {
     private var indicatorSizeControl: some View {
         HStack(spacing: 4) {
             Slider(value: $indicatorSize, in: 32 ... 80, step: 4)
-                .frame(width: 160)
+                .frame(maxWidth: .infinity)
 
             Text("\(Int(indicatorSize))")
                 .font(.body)
                 .monospacedDigit()
-                .frame(width: 20, alignment: .trailing)
+                .padding(.leading, 8)
+                .fixedSize()
         }
+        .padding(.horizontal, 24)
     }
 
     // MARK: - Font Size
@@ -233,13 +251,31 @@ public struct ToolBarView: View {
     // MARK: - Export Button
 
     private var exportButton: some View {
-        Button {
-            onExport()
-        } label: {
-            Label("Export", systemImage: "square.and.arrow.up")
-                .fixedSize()
+        VStack(spacing: 16) {
+            Button { onExport() } label: {
+                Image(systemName: "square.and.arrow.up")
+                    .font(.system(size: 34))
+            }
+            .buttonStyle(.borderedProminent)
+            .fixedSize()
+            
+            Button("Choose") {
+                chooseSaveLocation()
+            }
         }
-        .buttonStyle(.borderedProminent)
+    }
+    
+    // MARK: - Actions
+
+    private func chooseSaveLocation() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+
+        if panel.runModal() == .OK, let url = panel.url {
+            saveLocationPath = url.path()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Added customizable SF Symbol icon pickers for Do/Don't indicators. Introduced separate indicator label fields (max 10 characters) and panel title fields (max 30 characters) with fixed widths to prevent layout expansion. Icon pickers disabled for "text only" style, label fields disabled for "icon only" style.

## Changes
- `IndicatorIcon` enum with curated positive/negative SF Symbol options
- Icon pickers in toolbar indicator settings section
- Separate indicator label AppStorage keys from panel titles
- Character limits and fixed field widths to maintain UI stability
- All changes apply immediately to CodeEditorView and export

## Testing
- Build succeeds with no errors
- All controls apply changes immediately to indicator display
- Disable logic works correctly with indicator style changes