### PR TITLE
feat: add language/theme persistence and code editor limits

### DIFF
--- a/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
@@ -13,7 +13,13 @@ import SwiftUI
 /// Main content view with Do/Don't code panels
 public struct ContentView: View {
     @State private var viewModel = AppViewModel()
-    @State private var selectedLanguage: CodeLanguage = .swift
+
+    // Language is stored via @AppStorage in ToolBarView, we read it here to initialize panels
+    @AppStorage("selectedLanguage") private var selectedLanguageRaw: String = "swift"
+
+    private var selectedLanguage: CodeLanguage {
+        CodeLanguage.allLanguages.first { $0.id.rawValue == selectedLanguageRaw } ?? .swift
+    }
 
     // MARK: - Settings (via @AppStorage)
 
@@ -53,10 +59,10 @@ public struct ContentView: View {
     public var body: some View {
         VStack(spacing: 0) {
             ToolBarView(
-                selectedLanguage: $selectedLanguage,
                 doTitleSetting: $doTitleSetting,
                 dontTitleSetting: $dontTitleSetting,
-                onExport: { Task(operation: exportImage) }
+                onExport: { Task(operation: exportImage) },
+                onLanguageChange: { viewModel.setLanguage($0) }
             )
 
             panelsView
@@ -64,11 +70,14 @@ public struct ContentView: View {
         }
         .background(Color.contentBackground)
         .frame(minHeight: 400)
-        .onChange(of: selectedLanguage) { _, newValue in
-            viewModel.setLanguage(newValue)
-        }
         .onAppear {
+            // Initialize with stored language and titles on appear
+            viewModel.setLanguage(selectedLanguage)
             viewModel.update(doTitle: doTitleSetting, dontTitle: dontTitleSetting)
+        }
+        .onChange(of: selectedLanguageRaw) { _, _ in
+            // Update panels when language changes via AppStorage
+            viewModel.setLanguage(selectedLanguage)
         }
         .onChange(of: doTitleSetting) { _, newValue in
             viewModel.update(doTitle: newValue, dontTitle: dontTitleSetting)

--- a/BifcodePackage/Sources/BifcodeFeature/Views/CodeEditorView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/CodeEditorView.swift
@@ -121,6 +121,45 @@ public struct CodeEditorView: View {
         }
     }
 
+    // MARK: - Code Limits
+
+    /// Maximum characters per line
+    private static let maxLineLength = 210
+
+    /// Maximum number of lines
+    private static let maxLineCount = 24
+
+    /// Applies line length and line count limits to the code
+    private func applyCodeLimits() {
+        var lines = panel.code.components(separatedBy: "\n")
+
+        // Limit number of lines
+        if lines.count > Self.maxLineCount {
+            lines = Array(lines.prefix(Self.maxLineCount))
+        }
+
+        // Limit line length
+        lines = lines.map { line in
+            if line.count > Self.maxLineLength {
+                return String(line.prefix(Self.maxLineLength))
+            }
+            return line
+        }
+
+        let limitedCode = lines.joined(separator: "\n")
+        if limitedCode != panel.code {
+            panel.code = limitedCode
+        }
+    }
+
+    /// Unique identifier for forcing editor recreation when language, theme, or font changes
+    private var editorIdentifier: String {
+        "\(panel.id)-\(panel.language.id)-\(selectedThemeRaw)-\(Int(fontSize))"
+    }
+
+    /// Tracks if initial appearance has occurred to force editor recreation
+    @State private var hasAppeared = false
+
     private var sourceEditor: some View {
         SourceEditor(
             $panel.code,
@@ -128,7 +167,17 @@ public struct CodeEditorView: View {
             configuration: editorConfiguration,
             state: $panel.editorState
         )
+        .id(hasAppeared ? editorIdentifier : "initial")
+        .onAppear {
+            // Force recreation after initial appearance to apply stored settings
+            if !hasAppeared {
+                DispatchQueue.main.async {
+                    hasAppeared = true
+                }
+            }
+        }
         .onChange(of: panel.code) { _, _ in
+            applyCodeLimits()
             onCodeChange()
         }
     }

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ExportPanelView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ExportPanelView.swift
@@ -10,10 +10,10 @@ import CodeEditLanguages
 import CodeEditSourceEditor
 import SwiftUI
 
-/// Static code panel view optimized for ImageRenderer export
-/// Uses Text instead of SourceEditor for pure SwiftUI rendering
+/// Static code panel view for ImageRenderer export
+/// Uses SourceEditor with same settings as CodeEditorView for consistent rendering
 struct ExportPanelView: View {
-    let panel: CodePanel
+    @Bindable var panel: CodePanel
     let indicatorPosition: IndicatorPosition
     let indicatorStyle: IndicatorStyle
     let indicatorSize: CGFloat
@@ -22,6 +22,9 @@ struct ExportPanelView: View {
     let showTitle: Bool
     let fontSize: CGFloat
     let theme: EditorTheme
+
+    /// Editor state for the source editor
+    @State private var editorState = SourceEditorState()
 
     // MARK: - Body
 
@@ -66,9 +69,8 @@ struct ExportPanelView: View {
 
     private var editorArea: some View {
         ZStack(alignment: indicatorAlignment) {
-            // Static code display
-            codeContent
-                .padding(10)
+            // Code editor using CodeEditSourceEditor with same settings
+            sourceEditor
 
             // Indicator badge
             IndicatorBadgeView(
@@ -82,34 +84,31 @@ struct ExportPanelView: View {
         }
     }
 
-    private var codeContent: some View {
-        HStack(alignment: .top, spacing: 0) {
-            // Line numbers
-            lineNumbers
-                .padding(.trailing, 8)
-
-            // Code text with syntax highlighting colors from theme
-            Text(panel.code)
-                .font(.system(size: fontSize, design: .monospaced))
-                .foregroundStyle(Color(nsColor: theme.text.color))
-                .textSelection(.enabled)
-                .fixedSize(horizontal: false, vertical: true)
-
-            Spacer(minLength: 0)
-        }
+    /// Unique identifier for forcing editor recreation when language or theme changes
+    private var editorIdentifier: String {
+        "\(panel.id)-\(panel.language.id)-export"
     }
 
-    private var lineNumbers: some View {
-        let lines = panel.code.components(separatedBy: "\n")
-        let maxDigits = String(lines.count).count
+    private var sourceEditor: some View {
+        SourceEditor(
+            $panel.code,
+            language: panel.language,
+            configuration: editorConfiguration,
+            state: $editorState
+        )
+        .id(editorIdentifier)
+        .disabled(true) // Make non-interactive for export
+    }
 
-        return VStack(alignment: .trailing, spacing: 0) {
-            ForEach(1 ... max(lines.count, 1), id: \.self) { number in
-                Text(String(format: "%\(maxDigits)d", number))
-                    .font(.system(size: fontSize, design: .monospaced))
-                    .foregroundStyle(Color(nsColor: theme.invisibles.color))
-            }
-        }
+    private var editorConfiguration: SourceEditorConfiguration {
+        SourceEditorConfiguration(
+            appearance: .init(
+                theme: theme,
+                font: NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular),
+                wrapLines: false
+            ),
+            peripherals: .init(showMinimap: false, showFoldingRibbon: false)
+        )
     }
 
     private var indicatorAlignment: Alignment {
@@ -138,7 +137,7 @@ struct ExportPanelView: View {
         fontSize: 14,
         theme: .atomOneDark
     )
-    .frame(width: 400)
+    .frame(width: 400, height: 200)
     .padding()
     .background(Color.contentBackground)
 }
@@ -162,7 +161,7 @@ struct ExportPanelView: View {
         fontSize: 14,
         theme: .atomOneDark
     )
-    .frame(width: 400)
+    .frame(width: 400, height: 200)
     .padding()
     .background(Color.contentBackground)
 }

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
@@ -25,31 +25,38 @@ public struct ToolBarView: View {
     @AppStorage("selectedTheme") private var selectedThemeRaw: String = EditorThemeOption.atomOneDark.rawValue
 
     @AppStorage("saveLocation") private var saveLocationPath: String = ""
+    @AppStorage("selectedLanguage") private var selectedLanguageRaw: String = "swift"
 
     /// Current indicator style for disable logic
     private var currentIndicatorStyle: IndicatorStyle {
         IndicatorStyle(rawValue: indicatorStyle) ?? .iconAndText
     }
-    
+
+    /// Selected language derived from stored raw value
+    private var selectedLanguage: CodeLanguage {
+        CodeLanguage.allLanguages.first { $0.id.rawValue == selectedLanguageRaw } ?? .swift
+    }
+
     @Binding private var doTitleSetting: String
     @Binding private var dontTitleSetting: String
 
-    // MARK: - Bindings
+    // MARK: - Callbacks
 
-    @Binding var selectedLanguage: CodeLanguage
     var onExport: () -> Void
+    var onLanguageChange: (CodeLanguage) -> Void
 
     // MARK: - Initialization
 
-    public init(selectedLanguage: Binding<CodeLanguage>,
-                doTitleSetting: Binding<String>,
-                dontTitleSetting: Binding<String>,
-                onExport: @escaping () -> Void)
-    {
-        _selectedLanguage = selectedLanguage
+    public init(
+        doTitleSetting: Binding<String>,
+        dontTitleSetting: Binding<String>,
+        onExport: @escaping () -> Void,
+        onLanguageChange: @escaping (CodeLanguage) -> Void
+    ) {
         _doTitleSetting = doTitleSetting
         _dontTitleSetting = dontTitleSetting
         self.onExport = onExport
+        self.onLanguageChange = onLanguageChange
     }
 
     // MARK: - Body
@@ -165,13 +172,16 @@ public struct ToolBarView: View {
 
     private var languagePicker: some View {
         HStack(spacing: 4) {
-            Picker("", selection: $selectedLanguage) {
+            Picker("", selection: $selectedLanguageRaw) {
                 ForEach(commonLanguages, id: \.id) { lang in
-                    Text(lang.id.rawValue.capitalized).tag(lang)
+                    Text(lang.id.rawValue.capitalized).tag(lang.id.rawValue)
                 }
             }
             .pickerStyle(.menu)
             .fixedSize()
+            .onChange(of: selectedLanguageRaw) { _, _ in
+                onLanguageChange(selectedLanguage)
+            }
         }
     }
 
@@ -377,9 +387,9 @@ public struct ToolBarView: View {
 
 #Preview("ToolBarView") {
     ToolBarView(
-        selectedLanguage: .constant(.swift),
         doTitleSetting: .constant("1"),
         dontTitleSetting: .constant("2"),
-        onExport: {}
+        onExport: {},
+        onLanguageChange: { _ in }
     )
 }


### PR DESCRIPTION
Adds code editor limits and fixes language/theme persistence issues.

**Changes:**
- Added code line limits (max 210 chars/line, max 24 lines) enforced on input
- Persisted language selection to @AppStorage so preference survives app restart
- Fixed theme/language not applying on initial load via SourceEditor .id() recreation
- Replaced ExportPanelView text rendering with SourceEditor for consistent syntax highlighting
- Initialize panels with stored settings on app launch

All syntax highlighting and theme changes now apply immediately and persist across sessions.