### PR TITLE
docs: add comprehensive DocC documentation

### DIFF
--- a/BifcodePackage/Sources/BifcodeFeature/BifcodeFeature.docc/Architecture.md
+++ b/BifcodePackage/Sources/BifcodeFeature/BifcodeFeature.docc/Architecture.md
@@ -1,0 +1,172 @@
+# Architecture Overview
+
+Understand the design patterns and structure of BifcodeFeature.
+
+## Overview
+
+BifcodeFeature follows the Model-View-ViewModel (MVVM) architecture with Swift 6 strict concurrency throughout. This document explains the key architectural decisions and component relationships.
+
+### Design Principles
+
+1. **Strict Concurrency**: All shared types conform to `Sendable`
+2. **Main Actor Isolation**: UI-related code is isolated to `@MainActor`
+3. **Observable Pattern**: State management uses `@Observable` (not `ObservableObject`)
+4. **Persistence via @AppStorage**: User preferences automatically sync to UserDefaults
+
+### Component Hierarchy
+
+```
+BifcodeApp (@main)
+    └── ContentView
+        ├── ToolBarView
+        │   ├── Language Picker
+        │   ├── Theme Picker
+        │   ├── Layout Toggle
+        │   ├── Indicator Settings
+        │   └── Export Button
+        └── Panels
+            ├── CodeEditorView (Don't)
+            │   ├── Title Bar
+            │   ├── SourceEditor
+            │   └── IndicatorBadgeView
+            └── CodeEditorView (Do)
+                ├── Title Bar
+                ├── SourceEditor
+                └── IndicatorBadgeView
+```
+
+### State Management
+
+#### AppViewModel
+
+The central state container managing code panels and export functionality:
+
+```swift
+@MainActor
+@Observable
+public final class AppViewModel {
+    public let doPanel: CodePanel
+    public let dontPanel: CodePanel
+
+    public var saveLocation: URL { ... }
+    public func saveImage(_ image: NSImage) async throws
+}
+```
+
+#### CodePanel
+
+Observable model representing a single code editor:
+
+```swift
+@MainActor
+@Observable
+public final class CodePanel: Identifiable {
+    public let type: PanelType
+    public var code: String
+    public var title: String
+    public var language: CodeLanguage
+    public var editorState: SourceEditorState
+}
+```
+
+### Settings Architecture
+
+User preferences are stored via `@AppStorage` directly in views, enabling:
+
+- Automatic persistence to UserDefaults
+- Immediate UI updates when settings change
+- No manual state synchronization required
+
+| Setting Category | Storage Keys |
+|-----------------|--------------|
+| Code Style | `selectedLanguage`, `selectedTheme`, `fontSize`, `windowLayout` |
+| Panel Titles | `doTitle`, `dontTitle`, `showTitle` |
+| Indicators | `indicatorStyle`, `indicatorPosition`, `indicatorSize`, `doIndicatorIcon`, `dontIndicatorIcon`, `doIndicatorLabel`, `dontIndicatorLabel` |
+
+### Export Pipeline
+
+The export system uses offscreen window rendering (not `ImageRenderer`) because `ImageRenderer` cannot render `NSViewRepresentable` views like `SourceEditor`.
+
+```
+User taps Export
+        │
+        ▼
+Calculate dimensions from content
+        │
+        ▼
+Create ExportView with settings
+        │
+        ▼
+Wrap in NSHostingView
+        │
+        ▼
+Create offscreen NSWindow
+        │
+        ▼
+Wait for SourceEditor to render
+        │
+        ▼
+Capture via bitmapImageRepForCachingDisplay
+        │
+        ▼
+Scale to 2x for Retina
+        │
+        ▼
+Save as PNG via BookmarkManager
+```
+
+### Security-Scoped Bookmarks
+
+To persist folder access across app launches in a sandboxed environment:
+
+```swift
+@MainActor
+public final class BookmarkManager: Sendable {
+    public static let shared = BookmarkManager()
+
+    public func storeBookmark(for url: URL) throws
+    public func resolveBookmark() -> URL?
+    public func clearBookmark()
+}
+```
+
+**Workflow:**
+1. User selects folder via `NSOpenPanel`
+2. `BookmarkManager.storeBookmark(for:)` creates security-scoped bookmark
+3. On export, `resolveBookmark()` retrieves the URL
+4. `startAccessingSecurityScopedResource()` before file I/O
+5. `stopAccessingSecurityScopedResource()` after file I/O
+
+### Color System
+
+All colors use semantic naming via `Color+Semantic.swift`:
+
+| Category | Examples |
+|----------|----------|
+| Indicators | `indicatorDo`, `indicatorDont` |
+| Editor | `editorBackground`, `editorText`, `editorGutter` |
+| Window | `windowBackground`, `titleBarBackground`, `windowBorder` |
+| UI | `toolbarBackground`, `contentBackground`, `secondaryText` |
+
+Colors are defined in `Resources/Colors.xcassets` with light/dark mode variants.
+
+### Theme System
+
+Editor themes extend `EditorTheme` with predefined presets:
+
+- Atom One Dark
+- Dracula
+- GitHub Dark
+- Monokai
+- Nord
+- Solarized Dark
+- Xcode Default
+
+Each theme defines colors for text, keywords, strings, comments, and other syntax elements.
+
+## See Also
+
+- <doc:GettingStarted>
+- ``AppViewModel``
+- ``BookmarkManager``
+- ``EditorThemeOption``

--- a/BifcodePackage/Sources/BifcodeFeature/BifcodeFeature.docc/BifcodeFeature.md
+++ b/BifcodePackage/Sources/BifcodeFeature/BifcodeFeature.docc/BifcodeFeature.md
@@ -1,0 +1,81 @@
+# ``BifcodeFeature``
+
+A macOS application framework for generating beautiful code comparison images with customizable "Do's" and "Don'ts" indicators.
+
+## Overview
+
+BifcodeFeature provides a complete code comparison image generator for macOS. It enables developers to create side-by-side or stacked code panels with syntax highlighting, customizable indicators, and professional export capabilities.
+
+### Key Features
+
+- **Syntax Highlighting**: Support for 19+ programming languages via CodeEditSourceEditor
+- **Multiple Themes**: 7 professional editor themes including Atom One Dark, Dracula, and Monokai
+- **Flexible Layouts**: Horizontal (side-by-side) or vertical (stacked) panel arrangements
+- **Customizable Indicators**: Icons, labels, positions, and sizes for Do/Don't badges
+- **High-Quality Export**: 2x Retina PNG export with proper shadow rendering
+- **Persistent Settings**: All user preferences automatically saved via `@AppStorage`
+
+### Architecture
+
+The framework follows MVVM architecture with Swift 6 strict concurrency:
+
+```
+┌─────────────────────────────────────────────────┐
+│                  ContentView                     │
+│  ┌─────────────────┐  ┌─────────────────────┐  │
+│  │   ToolBarView   │  │    PanelsView       │  │
+│  └─────────────────┘  │  ┌───────────────┐  │  │
+│                       │  │ CodeEditorView│  │  │
+│                       │  └───────────────┘  │  │
+│                       └─────────────────────┘  │
+└─────────────────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────┐
+│              AppViewModel                        │
+│  ┌────────────┐    ┌────────────┐              │
+│  │  doPanel   │    │ dontPanel  │              │
+│  │ (CodePanel)│    │ (CodePanel)│              │
+│  └────────────┘    └────────────┘              │
+└─────────────────────────────────────────────────┘
+```
+
+## Topics
+
+### Essentials
+
+- <doc:GettingStarted>
+- <doc:Architecture>
+- ``ContentView``
+
+### View Models
+
+- ``AppViewModel``
+- ``CodePanel``
+- ``PanelType``
+
+### Views
+
+- ``CodeEditorView``
+- ``ToolBarView``
+- ``IndicatorBadgeView``
+
+### Settings and Configuration
+
+- ``IndicatorPosition``
+- ``IndicatorStyle``
+- ``IndicatorIcon``
+- ``WindowLayout``
+- ``EditorThemeOption``
+
+### Export
+
+- ``ExportError``
+
+### Services
+
+- ``BookmarkManager``
+
+### Extensions
+
+- ``Swift/Color``

--- a/BifcodePackage/Sources/BifcodeFeature/BifcodeFeature.docc/GettingStarted.md
+++ b/BifcodePackage/Sources/BifcodeFeature/BifcodeFeature.docc/GettingStarted.md
@@ -1,0 +1,85 @@
+# Getting Started with BifcodeFeature
+
+Learn how to use BifcodeFeature to create professional code comparison images.
+
+## Overview
+
+BifcodeFeature is a SwiftUI-based framework for macOS that generates beautiful code comparison images. This guide walks you through the basic usage and customization options.
+
+### Prerequisites
+
+- macOS 15.0+ (Sequoia)
+- Xcode 16.0+
+- Swift 6.0+
+
+### Basic Usage
+
+The simplest way to use BifcodeFeature is to present `ContentView` in your app:
+
+```swift
+import SwiftUI
+import BifcodeFeature
+
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .windowStyle(.hiddenTitleBar)
+        .defaultSize(width: 800, height: 600)
+    }
+}
+```
+
+### The User Interface
+
+The main interface consists of three sections:
+
+1. **Toolbar** - Configure code style, indicators, and export
+2. **Don't Panel** - The "Don't" code example (left/top)
+3. **Do Panel** - The "Do" code example (right/bottom)
+
+### Code Style Settings
+
+| Setting | Description | Range |
+|---------|-------------|-------|
+| Language | Programming language for syntax highlighting | 19 languages |
+| Theme | Color scheme for the editor | 7 themes |
+| Layout | Panel arrangement | Horizontal/Vertical |
+| Font Size | Code font size | 10-24pt |
+
+### Indicator Settings
+
+| Setting | Description | Range |
+|---------|-------------|-------|
+| Style | Icon only, text only, or both | 3 options |
+| Position | Badge placement | Top-right/Bottom-right |
+| Size | Badge size | 32-80px |
+| Icons | SF Symbols for Do/Don't | 5 each |
+| Labels | Custom text labels | 10 chars max |
+
+### Export
+
+Click the export button (upload icon) to save your comparison as a PNG image:
+
+1. The image is exported at 2x resolution for Retina displays
+2. Transparent background with drop shadows
+3. Saved to Desktop by default, or your chosen folder
+4. Filename format: `bifcode-[timestamp].png`
+
+### Choosing a Save Location
+
+To change where exports are saved:
+
+1. Click "Choose" below the export button
+2. Select your preferred folder
+3. The app will remember this location across launches
+
+> Note: The app uses security-scoped bookmarks to maintain folder access in sandboxed environments.
+
+## See Also
+
+- <doc:Architecture>
+- ``ContentView``
+- ``AppViewModel``

--- a/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
@@ -10,7 +10,57 @@ import CodeEditLanguages
 import CodeEditSourceEditor
 import SwiftUI
 
-/// Main content view with Do/Don't code panels
+/// The main view of the Bifcode application displaying side-by-side code comparison panels.
+///
+/// `ContentView` is the root view that orchestrates the entire user interface, including
+/// the toolbar, code editor panels, and the export pipeline. It manages user settings
+/// via `@AppStorage` and coordinates between the UI and ``AppViewModel``.
+///
+/// ## Overview
+///
+/// The view consists of two main sections:
+/// 1. **Toolbar** - Language selection, panel titles, indicator settings, and export button
+/// 2. **Panels Area** - Two ``CodeEditorView`` instances for Do's and Don'ts code
+///
+/// ## Layout Modes
+///
+/// The panels can be arranged in two layouts controlled by ``WindowLayout``:
+/// - **Horizontal** - Panels side-by-side (default)
+/// - **Vertical** - Panels stacked with scroll support
+///
+/// ## Export Pipeline
+///
+/// Export uses an offscreen `NSWindow` rendering technique because standard
+/// `ImageRenderer` cannot capture `NSViewRepresentable` views like `SourceEditor`.
+/// The pipeline:
+/// 1. Calculates dimensions based on code content and font metrics
+/// 2. Creates an ``ExportView`` with the calculated dimensions
+/// 3. Hosts in an offscreen `NSWindow` for proper layer rendering
+/// 4. Captures via `bitmapImageRepForCachingDisplay` at 2x Retina scale
+/// 5. Saves to user-selected location via ``AppViewModel``
+///
+/// ## Settings Persistence
+///
+/// All user preferences are stored via `@AppStorage`:
+/// - Panel titles and indicator labels
+/// - Indicator icons (SF Symbol names)
+/// - Layout, position, style settings
+/// - Font size and theme selection
+///
+/// ## Topics
+///
+/// ### Related Views
+///
+/// - ``ToolBarView``
+/// - ``CodeEditorView``
+/// - ``ExportView``
+///
+/// ### Supporting Types
+///
+/// - ``AppViewModel``
+/// - ``WindowLayout``
+/// - ``IndicatorPosition``
+/// - ``IndicatorStyle``
 public struct ContentView: View {
     @State private var viewModel = AppViewModel()
 
@@ -153,6 +203,13 @@ public struct ContentView: View {
 
     // MARK: - Export
 
+    /// Exports the current code panels as a PNG image.
+    ///
+    /// This method orchestrates the export pipeline:
+    /// 1. Renders the panels to an `NSImage` via ``renderExportViewToImage()``
+    /// 2. Saves the image using ``AppViewModel/saveImage(_:)``
+    ///
+    /// > Note: Export is disabled when both code panels are empty.
     @MainActor
     private func exportImage() async {
         // Use NSHostingView + snapshot instead of ImageRenderer
@@ -171,8 +228,33 @@ public struct ContentView: View {
         }
     }
 
-    /// Renders the export view to an NSImage using an offscreen window
-    /// This works with NSViewRepresentable views (like SourceEditor) unlike ImageRenderer
+    /// Renders the export view to an NSImage using an offscreen window.
+    ///
+    /// This method uses an offscreen `NSWindow` technique because `ImageRenderer`
+    /// cannot capture `NSViewRepresentable` views like `SourceEditor` from
+    /// CodeEditSourceEditor.
+    ///
+    /// ## Rendering Steps
+    ///
+    /// 1. **Size Calculation** - Computes dimensions based on:
+    ///    - Longest line in both code panels
+    ///    - Monospace font character width
+    ///    - Line counts for each panel (minimum 5 lines)
+    ///    - Additional space for gutters, indicators, padding, and shadows
+    ///
+    /// 2. **View Setup** - Creates an ``ExportView`` with calculated dimensions
+    ///    and hosts it in an `NSHostingView`
+    ///
+    /// 3. **Offscreen Window** - Creates a borderless window positioned off-screen
+    ///    to allow proper layer rendering
+    ///
+    /// 4. **Render Wait** - Waits for `SourceEditor` to fully render using
+    ///    multiple short sleeps with `Task.yield()`
+    ///
+    /// 5. **Capture** - Uses `bitmapImageRepForCachingDisplay` for proper layer
+    ///    capture, then scales to 2x for Retina displays
+    ///
+    /// - Returns: The rendered image at 2x Retina scale, or `nil` if rendering fails.
     @MainActor
     private func renderExportViewToImage() async -> NSImage? {
         // Calculate size based on layout and content

--- a/BifcodePackage/Sources/BifcodeFeature/Extensions/Color+Semantic.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Extensions/Color+Semantic.swift
@@ -7,6 +7,50 @@
 
 import SwiftUI
 
+/// Semantic color definitions for Bifcode UI elements.
+///
+/// This extension provides named colors that load from the asset catalog
+/// with automatic light/dark mode support. All colors are defined in
+/// `Colors.xcassets` within the BifcodeFeature module.
+///
+/// ## Color Categories
+///
+/// The colors are organized into functional groups:
+///
+/// ### Indicator Colors
+/// - ``indicatorDo`` - Green for positive "Do's" examples
+/// - ``indicatorDont`` - Red for negative "Don'ts" examples
+///
+/// ### Editor Colors
+/// - ``editorBackground`` - Code editor background
+/// - ``editorText`` - Default code text
+/// - ``editorLineNumber`` - Line number gutter text
+/// - ``editorGutter`` - Line number gutter background
+/// - ``editorCloseButton`` - Traffic light placeholder
+///
+/// ### Window Colors
+/// - ``windowBackground`` - Main window background
+/// - ``titleBarBackground`` - Panel title bar
+/// - ``titleText`` - Title bar text
+/// - ``windowBorder`` - Panel border stroke
+///
+/// ### UI Colors
+/// - ``toolbarBackground`` - Toolbar container
+/// - ``contentBackground`` - Main content area
+/// - ``secondaryText`` - De-emphasized text
+///
+/// ## Usage
+///
+/// ```swift
+/// Text("Do's")
+///     .foregroundColor(.indicatorDo)
+///
+/// Rectangle()
+///     .fill(Color.editorBackground)
+/// ```
+///
+/// > Important: Never use hardcoded colors like `.red` or `.green`.
+/// > Always use semantic colors for theme consistency.
 extension Color {
     // MARK: - Indicator Colors
 

--- a/BifcodePackage/Sources/BifcodeFeature/Models/CodePanel.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Models/CodePanel.swift
@@ -9,28 +9,137 @@ import CodeEditLanguages
 import CodeEditSourceEditor
 import Foundation
 
-/// Represents a code panel (Do or Don't)
+/// The type of code panel, either "Do" (positive example) or "Don't" (negative example).
+///
+/// `PanelType` determines the visual appearance and default indicator settings
+/// for a ``CodePanel``. Do panels typically display green checkmarks, while
+/// Don't panels display red X marks.
+///
+/// ## Topics
+///
+/// ### Panel Types
+///
+/// - ``doPanel``
+/// - ``dontPanel``
 public enum PanelType: String, Sendable {
+    /// A panel displaying positive code examples (best practices).
+    ///
+    /// Do panels show code that developers should follow. By default,
+    /// they display a green checkmark indicator and "Do's" label.
     case doPanel = "do"
+
+    /// A panel displaying negative code examples (anti-patterns).
+    ///
+    /// Don't panels show code that developers should avoid. By default,
+    /// they display a red X indicator and "Don'ts" label.
     case dontPanel = "dont"
 }
 
-/// Model for a code editor panel
+/// A model representing a single code editor panel with syntax highlighting.
+///
+/// `CodePanel` is the data model for a code editor in Bifcode. Each panel
+/// contains the code content, display title, programming language for
+/// syntax highlighting, and editor state (cursor position, scroll, etc.).
+///
+/// ## Overview
+///
+/// The app uses two `CodePanel` instances: one for "Do's" examples and one
+/// for "Don'ts" examples. Both are managed by ``AppViewModel``.
+///
+/// ```swift
+/// // Create a new panel
+/// let panel = CodePanel(type: .doPanel, title: "Best Practices")
+/// panel.code = "let userName = \"Alice\""
+/// panel.language = .swift
+///
+/// // Access in a view
+/// @Bindable var panel: CodePanel
+/// Text(panel.code)
+/// ```
+///
+/// ## Thread Safety
+///
+/// `CodePanel` is isolated to `@MainActor` and uses the `@Observable` macro
+/// for reactive updates. It should only be accessed from the main thread.
+///
+/// ## Topics
+///
+/// ### Creating a Panel
+///
+/// - ``init(type:title:language:)``
+///
+/// ### Panel Properties
+///
+/// - ``id``
+/// - ``type``
+/// - ``code``
+/// - ``title``
+/// - ``language``
+/// - ``editorState``
 @MainActor
 @Observable
 public final class CodePanel: Identifiable {
+    /// A unique identifier for the panel.
+    ///
+    /// Used by SwiftUI for efficient view updates when panels are
+    /// displayed in lists or collections.
     public let id = UUID()
+
+    /// The type of panel (Do or Don't).
+    ///
+    /// This determines the default indicator appearance and semantics
+    /// of the code displayed.
     public let type: PanelType
 
+    /// The source code content displayed in the editor.
+    ///
+    /// This is the user-editable code that receives syntax highlighting.
+    /// The code is limited to 24 lines and 210 characters per line by
+    /// ``CodeEditorView``.
     public var code: String = ""
+
+    /// The display title shown in the panel's title bar.
+    ///
+    /// Titles are displayed with a document icon and support up to
+    /// 70 characters. Longer titles are truncated with ellipsis.
     public var title: String
 
-    /// The language to use for highlighting
+    /// The programming language used for syntax highlighting.
+    ///
+    /// Changing this property triggers the editor to re-render with
+    /// the appropriate syntax highlighting rules. Supports 19+ languages
+    /// via CodeEditLanguages.
+    ///
+    /// ```swift
+    /// panel.language = .python  // Highlight as Python
+    /// panel.language = .swift   // Highlight as Swift
+    /// ```
     public var language: CodeLanguage
 
-    /// Editor state for cursor position, scroll, etc.
+    /// The editor state containing cursor position, selection, and scroll.
+    ///
+    /// This state is managed by `SourceEditor` from CodeEditSourceEditor.
+    /// It persists cursor position and selection between renders.
     public var editorState: SourceEditorState
 
+    /// Creates a new code panel with the specified configuration.
+    ///
+    /// - Parameters:
+    ///   - type: The panel type (Do or Don't).
+    ///   - title: The display title. Defaults to empty string.
+    ///   - language: The syntax highlighting language. Defaults to Swift.
+    ///
+    /// ```swift
+    /// // Create a Swift "Do's" panel
+    /// let doPanel = CodePanel(type: .doPanel, title: "Do's")
+    ///
+    /// // Create a Python "Don'ts" panel
+    /// let dontPanel = CodePanel(
+    ///     type: .dontPanel,
+    ///     title: "Avoid This",
+    ///     language: .python
+    /// )
+    /// ```
     public init(type: PanelType, title: String = "", language: CodeLanguage = .swift) {
         self.type = type
         self.title = title

--- a/BifcodePackage/Sources/BifcodeFeature/Models/SettingsTypes.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Models/SettingsTypes.swift
@@ -9,11 +9,41 @@ import AppKit
 import CodeEditSourceEditor
 import Foundation
 
-/// Indicator position options
+// MARK: - Indicator Position
+
+/// The position of the indicator badge within a code panel.
+///
+/// Indicator badges can be placed in different corners of the code editor
+/// to accommodate various design preferences and code layouts.
+///
+/// ## Usage
+///
+/// The position is stored via `@AppStorage` and applied to both panels:
+///
+/// ```swift
+/// @AppStorage("indicatorPosition") private var indicatorPosition = IndicatorPosition.topRight.rawValue
+/// ```
+///
+/// ## Topics
+///
+/// ### Positions
+///
+/// - ``topRight``
+/// - ``bottomRight``
 public enum IndicatorPosition: String, CaseIterable, Sendable {
+    /// Places the indicator in the top-right corner of the editor.
+    ///
+    /// This is the default position, ideal for code that starts from
+    /// the top and doesn't require immediate visual attention.
     case topRight = "top-right"
+
+    /// Places the indicator in the bottom-right corner of the editor.
+    ///
+    /// Useful when the code content starts with important information
+    /// that shouldn't be obscured by the badge.
     case bottomRight = "bottom-right"
 
+    /// A human-readable label for display in pickers.
     public var label: String {
         switch self {
         case .topRight: "Top Right"
@@ -22,12 +52,46 @@ public enum IndicatorPosition: String, CaseIterable, Sendable {
     }
 }
 
-/// Indicator style options
+// MARK: - Indicator Style
+
+/// The visual style of the indicator badge.
+///
+/// Controls whether the badge displays an icon, text label, or both.
+/// This allows users to customize the visual density of indicators.
+///
+/// ## Usage
+///
+/// ```swift
+/// @AppStorage("indicatorStyle") private var indicatorStyle = IndicatorStyle.iconAndText.rawValue
+/// ```
+///
+/// ## Topics
+///
+/// ### Styles
+///
+/// - ``iconOnly``
+/// - ``textOnly``
+/// - ``iconAndText``
 public enum IndicatorStyle: String, CaseIterable, Sendable {
+    /// Shows only the SF Symbol icon without text.
+    ///
+    /// Creates a minimal, icon-only badge. The icon size is 60% of
+    /// the badge size parameter.
     case iconOnly = "icon"
+
+    /// Shows only the text label without an icon.
+    ///
+    /// Displays the label text (e.g., "Do's" or "Don'ts") without
+    /// any icon. Text size is 30% of the badge size parameter.
     case textOnly = "text"
+
+    /// Shows both the icon and text label.
+    ///
+    /// The default style, displaying the icon above the text label
+    /// for maximum clarity.
     case iconAndText = "both"
 
+    /// A human-readable label for display in pickers.
     public var label: String {
         switch self {
         case .iconOnly: "Icon Only"
@@ -37,40 +101,143 @@ public enum IndicatorStyle: String, CaseIterable, Sendable {
     }
 }
 
-/// Curated SF Symbol options for indicators
+// MARK: - Indicator Icon
+
+/// Curated SF Symbol icons for indicator badges.
+///
+/// Provides a curated selection of SF Symbols appropriate for
+/// "Do" (positive) and "Don't" (negative) indicators. Icons are
+/// grouped by semantic meaning for easy selection in the UI.
+///
+/// ## Usage
+///
+/// Access icons by category for pickers:
+///
+/// ```swift
+/// // For "Do" panels
+/// let doIcons = IndicatorIcon.positiveIcons
+///
+/// // For "Don't" panels
+/// let dontIcons = IndicatorIcon.negativeIcons
+/// ```
+///
+/// ## Topics
+///
+/// ### Positive Icons
+///
+/// - ``checkmark``
+/// - ``checkmarkCircle``
+/// - ``checkmarkSquare``
+/// - ``thumbsUp``
+/// - ``star``
+///
+/// ### Negative Icons
+///
+/// - ``xmark``
+/// - ``xmarkCircle``
+/// - ``xmarkSquare``
+/// - ``thumbsDown``
+/// - ``warning``
+///
+/// ### Icon Access
+///
+/// - ``systemName``
+/// - ``positiveIcons``
+/// - ``negativeIcons``
 public enum IndicatorIcon: String, CaseIterable, Sendable {
     // Positive indicators
+
+    /// A simple checkmark icon.
     case checkmark
+
+    /// A checkmark inside a circle.
     case checkmarkCircle = "checkmark.circle"
+
+    /// A checkmark inside a square.
     case checkmarkSquare = "checkmark.square"
+
+    /// A thumbs up hand gesture.
     case thumbsUp = "hand.thumbsup"
+
+    /// A filled star icon.
     case star = "star.fill"
 
     // Negative indicators
+
+    /// A simple X mark icon.
     case xmark
+
+    /// An X mark inside a circle.
     case xmarkCircle = "xmark.circle"
+
+    /// An X mark inside a square.
     case xmarkSquare = "xmark.square"
+
+    /// A thumbs down hand gesture.
     case thumbsDown = "hand.thumbsdown"
+
+    /// An exclamation mark in a triangle (warning).
     case warning = "exclamationmark.triangle"
 
+    /// The SF Symbol system name for this icon.
+    ///
+    /// Use this value with `Image(systemName:)`:
+    ///
+    /// ```swift
+    /// Image(systemName: icon.systemName)
+    /// ```
     public var systemName: String { rawValue }
 
-    /// Icons suitable for "Do" indicators
+    /// Icons suitable for "Do" (positive) indicators.
+    ///
+    /// Returns: checkmark, checkmark.circle, checkmark.square,
+    /// hand.thumbsup, star.fill
     public static var positiveIcons: [IndicatorIcon] {
         [.checkmark, .checkmarkCircle, .checkmarkSquare, .thumbsUp, .star]
     }
 
-    /// Icons suitable for "Don't" indicators
+    /// Icons suitable for "Don't" (negative) indicators.
+    ///
+    /// Returns: xmark, xmark.circle, xmark.square,
+    /// hand.thumbsdown, exclamationmark.triangle
     public static var negativeIcons: [IndicatorIcon] {
         [.xmark, .xmarkCircle, .xmarkSquare, .thumbsDown, .warning]
     }
 }
 
-/// Window layout options
+// MARK: - Window Layout
+
+/// The arrangement of code panels in the main view.
+///
+/// Controls whether the Do and Don't panels are displayed
+/// side-by-side (horizontal) or stacked (vertical).
+///
+/// ## Usage
+///
+/// ```swift
+/// @AppStorage("windowLayout") private var windowLayout = WindowLayout.horizontal.rawValue
+/// ```
+///
+/// ## Topics
+///
+/// ### Layouts
+///
+/// - ``horizontal``
+/// - ``vertical``
 public enum WindowLayout: String, CaseIterable, Sendable {
+    /// Panels are arranged side-by-side horizontally.
+    ///
+    /// The Don't panel appears on the left, and the Do panel
+    /// appears on the right. Best for wide displays.
     case horizontal
+
+    /// Panels are stacked vertically.
+    ///
+    /// The Don't panel appears on top, and the Do panel
+    /// appears below. Best for narrow displays or portrait mode.
     case vertical
 
+    /// A human-readable label for display in pickers.
     public var label: String {
         switch self {
         case .horizontal: "Side by Side"
@@ -81,16 +248,97 @@ public enum WindowLayout: String, CaseIterable, Sendable {
 
 // MARK: - Editor Themes
 
-/// Available editor theme options
+/// Available syntax highlighting themes for the code editor.
+///
+/// `EditorThemeOption` provides a curated selection of popular code editor
+/// themes. Each theme defines colors for text, keywords, strings, comments,
+/// and other syntax elements.
+///
+/// ## Usage
+///
+/// Select a theme and access its underlying `EditorTheme`:
+///
+/// ```swift
+/// @AppStorage("selectedTheme") private var selectedTheme = EditorThemeOption.atomOneDark.rawValue
+///
+/// // Get the EditorTheme for CodeEditSourceEditor
+/// let theme = EditorThemeOption.atomOneDark.editorTheme
+/// ```
+///
+/// ## Available Themes
+///
+/// | Theme | Description |
+/// |-------|-------------|
+/// | Atom One Dark | Popular dark theme from Atom editor |
+/// | Dracula | High contrast dark theme |
+/// | GitHub Dark | GitHub's official dark mode |
+/// | Monokai | Classic theme from Sublime Text |
+/// | Nord | Arctic, bluish color palette |
+/// | Solarized Dark | Solarized dark variant |
+/// | Xcode Default | macOS Xcode default dark theme |
+///
+/// ## Topics
+///
+/// ### Themes
+///
+/// - ``atomOneDark``
+/// - ``dracula``
+/// - ``githubDark``
+/// - ``monokai``
+/// - ``nord``
+/// - ``solarizedDark``
+/// - ``xcodeDefault``
+///
+/// ### Accessing Theme Data
+///
+/// - ``label``
+/// - ``editorTheme``
 public enum EditorThemeOption: String, CaseIterable, Sendable {
+    /// Atom One Dark theme.
+    ///
+    /// A popular dark theme originally from the Atom editor.
+    /// Features a dark gray background with muted, readable colors.
     case atomOneDark = "atom-one-dark"
+
+    /// Dracula theme.
+    ///
+    /// A high-contrast dark theme with vibrant colors.
+    /// Features a purple/pink accent color scheme.
     case dracula
+
+    /// GitHub Dark theme.
+    ///
+    /// GitHub's official dark mode color scheme.
+    /// Features a very dark background with blue accents.
     case githubDark = "github-dark"
+
+    /// Monokai theme.
+    ///
+    /// A classic theme originally from Sublime Text.
+    /// Features warm colors on a dark brown-gray background.
     case monokai
+
+    /// Nord theme.
+    ///
+    /// An arctic, bluish color palette inspired by polar nights.
+    /// Features cool blue and gray tones.
     case nord
+
+    /// Solarized Dark theme.
+    ///
+    /// The dark variant of the Solarized color scheme.
+    /// Features a teal-tinged dark background with carefully
+    /// chosen contrasting colors.
     case solarizedDark = "solarized-dark"
+
+    /// Xcode Default Dark theme.
+    ///
+    /// The default dark theme from Apple's Xcode.
+    /// Features a very dark background with the familiar
+    /// Xcode syntax coloring.
     case xcodeDefault = "xcode-default"
 
+    /// A human-readable label for display in pickers.
     public var label: String {
         switch self {
         case .atomOneDark: "Atom One Dark"
@@ -103,7 +351,15 @@ public enum EditorThemeOption: String, CaseIterable, Sendable {
         }
     }
 
-    /// Converts to CodeEditSourceEditor's EditorTheme
+    /// The underlying `EditorTheme` for CodeEditSourceEditor.
+    ///
+    /// Use this property to configure the `SourceEditor` appearance:
+    ///
+    /// ```swift
+    /// SourceEditorConfiguration(
+    ///     appearance: .init(theme: selectedTheme.editorTheme, ...)
+    /// )
+    /// ```
     public var editorTheme: EditorTheme {
         switch self {
         case .atomOneDark: .atomOneDark
@@ -119,8 +375,21 @@ public enum EditorThemeOption: String, CaseIterable, Sendable {
 
 // MARK: - EditorTheme Presets
 
+/// Extension providing predefined theme presets for `EditorTheme`.
+///
+/// Each theme defines complete color settings for syntax highlighting:
+/// - Text colors (default, keywords, types, variables)
+/// - String and number literals
+/// - Comments
+/// - Editor chrome (background, selection, line highlight)
+///
+/// > Note: These properties use `nonisolated(unsafe)` because they are
+/// > constant static values that don't require actor isolation.
 extension EditorTheme {
-    /// Atom One Dark theme
+    /// Atom One Dark theme preset.
+    ///
+    /// A popular dark theme with a `#282c34` background and muted,
+    /// readable syntax colors.
     public nonisolated(unsafe) static let atomOneDark = EditorTheme(
         text: .init(color: NSColor(red: 0.67, green: 0.69, blue: 0.75, alpha: 1.0)),
         insertionPoint: .white,
@@ -140,7 +409,10 @@ extension EditorTheme {
         comments: .init(color: NSColor(red: 0.36, green: 0.40, blue: 0.44, alpha: 1.0))
     )
 
-    /// Dracula theme
+    /// Dracula theme preset.
+    ///
+    /// A high-contrast dark theme with vibrant purple and pink accents
+    /// on a `#282a36` background.
     public nonisolated(unsafe) static let dracula = EditorTheme(
         text: .init(color: NSColor(red: 0.97, green: 0.97, blue: 0.95, alpha: 1.0)),
         insertionPoint: .white,
@@ -160,7 +432,10 @@ extension EditorTheme {
         comments: .init(color: NSColor(red: 0.38, green: 0.45, blue: 0.55, alpha: 1.0))
     )
 
-    /// GitHub Dark theme
+    /// GitHub Dark theme preset.
+    ///
+    /// GitHub's official dark mode color scheme with a very dark
+    /// `#0d1117` background and blue accents.
     public nonisolated(unsafe) static let githubDark = EditorTheme(
         text: .init(color: NSColor(red: 0.79, green: 0.82, blue: 0.87, alpha: 1.0)),
         insertionPoint: .white,
@@ -180,7 +455,10 @@ extension EditorTheme {
         comments: .init(color: NSColor(red: 0.53, green: 0.57, blue: 0.63, alpha: 1.0))
     )
 
-    /// Monokai theme
+    /// Monokai theme preset.
+    ///
+    /// A classic theme from Sublime Text with warm colors on a
+    /// `#272822` brown-gray background.
     public nonisolated(unsafe) static let monokai = EditorTheme(
         text: .init(color: NSColor(red: 0.97, green: 0.97, blue: 0.95, alpha: 1.0)),
         insertionPoint: .white,
@@ -200,7 +478,10 @@ extension EditorTheme {
         comments: .init(color: NSColor(red: 0.46, green: 0.44, blue: 0.37, alpha: 1.0))
     )
 
-    /// Nord theme
+    /// Nord theme preset.
+    ///
+    /// An arctic, bluish color palette with cool blue-gray tones
+    /// on a `#2e3440` background.
     public nonisolated(unsafe) static let nord = EditorTheme(
         text: .init(color: NSColor(red: 0.85, green: 0.87, blue: 0.91, alpha: 1.0)),
         insertionPoint: .white,
@@ -220,7 +501,10 @@ extension EditorTheme {
         comments: .init(color: NSColor(red: 0.38, green: 0.43, blue: 0.50, alpha: 1.0))
     )
 
-    /// Solarized Dark theme
+    /// Solarized Dark theme preset.
+    ///
+    /// The dark variant of Solarized with a teal-tinged `#002b36`
+    /// background and carefully balanced colors.
     public nonisolated(unsafe) static let solarizedDark = EditorTheme(
         text: .init(color: NSColor(red: 0.51, green: 0.58, blue: 0.59, alpha: 1.0)),
         insertionPoint: .white,
@@ -240,7 +524,10 @@ extension EditorTheme {
         comments: .init(color: NSColor(red: 0.35, green: 0.43, blue: 0.46, alpha: 1.0))
     )
 
-    /// Xcode Default (Dark) theme
+    /// Xcode Default Dark theme preset.
+    ///
+    /// Apple's default dark theme for Xcode with a very dark
+    /// `#1c1c1e` background and familiar Xcode syntax coloring.
     public nonisolated(unsafe) static let xcodeDefault = EditorTheme(
         text: .init(color: NSColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)),
         insertionPoint: .white,

--- a/BifcodePackage/Sources/BifcodeFeature/Services/BookmarkManager.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Services/BookmarkManager.swift
@@ -9,14 +9,60 @@ import Foundation
 
 /// Manages security-scoped URL bookmarks for persistent file access across app launches.
 ///
-/// This manager handles the creation, storage, and resolution of security-scoped bookmarks
-/// that allow a sandboxed macOS app to maintain access to user-selected directories.
+/// `BookmarkManager` enables a sandboxed macOS app to maintain access to user-selected
+/// directories across app restarts. It handles the creation, storage, and resolution of
+/// security-scoped bookmarks using macOS security APIs.
 ///
-/// Usage:
-/// 1. When user selects a folder via NSOpenPanel, call `storeBookmark(for:)`
-/// 2. To access the stored location, call `resolveBookmark()` and use the returned URL
-/// 3. Before file operations, call `startAccessingSecurityScopedResource()` on the URL
-/// 4. After file operations, call `stopAccessingSecurityScopedResource()` on the URL
+/// ## Overview
+///
+/// In sandboxed apps, users must explicitly grant access to directories outside the
+/// app's container. Security-scoped bookmarks preserve this access between sessions.
+///
+/// ## Usage
+///
+/// The typical workflow for using `BookmarkManager`:
+///
+/// ```swift
+/// // 1. User selects a folder via NSOpenPanel
+/// let panel = NSOpenPanel()
+/// panel.canChooseDirectories = true
+/// if panel.runModal() == .OK, let url = panel.url {
+///     // 2. Store the bookmark
+///     try BookmarkManager.shared.storeBookmark(for: url)
+/// }
+///
+/// // 3. Later, resolve the bookmark to get the URL
+/// if let savedURL = BookmarkManager.shared.resolveBookmark() {
+///     // 4. Start security-scoped access
+///     guard savedURL.startAccessingSecurityScopedResource() else {
+///         throw SomeError.accessDenied
+///     }
+///
+///     defer {
+///         // 5. Stop access when done
+///         savedURL.stopAccessingSecurityScopedResource()
+///     }
+///
+///     // Perform file operations...
+/// }
+/// ```
+///
+/// ## Topics
+///
+/// ### Accessing the Shared Instance
+///
+/// - ``shared``
+///
+/// ### Managing Bookmarks
+///
+/// - ``storeBookmark(for:)``
+/// - ``resolveBookmark()``
+/// - ``clearBookmark()``
+///
+/// ### Querying State
+///
+/// - ``hasBookmark``
+/// - ``bookmarkedLocationName``
 @MainActor
 public final class BookmarkManager: Sendable {
     // MARK: - Singleton

--- a/BifcodePackage/Sources/BifcodeFeature/ViewModels/AppViewModel.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/ViewModels/AppViewModel.swift
@@ -9,13 +9,69 @@ import CodeEditLanguages
 import Foundation
 import SwiftUI
 
-/// Main application view model
+/// The main view model managing application state and export functionality.
+///
+/// `AppViewModel` is the central state container for the Bifcode application.
+/// It manages the Do and Don't code panels, handles export operations, and
+/// coordinates with ``BookmarkManager`` for persistent save location access.
+///
+/// ## Overview
+///
+/// The view model maintains two ``CodePanel`` instances representing the
+/// "Do's" and "Don'ts" code examples that users can edit and export.
+///
+/// ```swift
+/// @State private var viewModel = AppViewModel()
+///
+/// // Access panels
+/// let doCode = viewModel.doPanel.code
+/// let dontCode = viewModel.dontPanel.code
+///
+/// // Update language for both panels
+/// viewModel.setLanguage(.python)
+///
+/// // Export current view
+/// try await viewModel.saveImage(capturedImage)
+/// ```
+///
+/// ## Topics
+///
+/// ### Creating a View Model
+///
+/// - ``init()``
+///
+/// ### Accessing Panels
+///
+/// - ``doPanel``
+/// - ``dontPanel``
+///
+/// ### Managing Languages
+///
+/// - ``setLanguage(_:)``
+/// - ``update(doTitle:dontTitle:)``
+///
+/// ### Export
+///
+/// - ``saveImage(_:)``
+/// - ``saveLocation``
+/// - ``hasCustomSaveLocation``
+/// - ``saveLocationName``
 @MainActor
 @Observable
 public final class AppViewModel {
     // MARK: - Properties
 
+    /// The "Do's" code panel containing positive code examples.
+    ///
+    /// This panel displays code that demonstrates best practices or
+    /// recommended approaches. The indicator badge shows a green checkmark
+    /// by default.
     public let doPanel: CodePanel
+
+    /// The "Don'ts" code panel containing negative code examples.
+    ///
+    /// This panel displays code that demonstrates anti-patterns or
+    /// approaches to avoid. The indicator badge shows a red X by default.
     public let dontPanel: CodePanel
 
     // MARK: - Save Location
@@ -43,6 +99,11 @@ public final class AppViewModel {
 
     // MARK: - Initialization
 
+    /// Creates a new view model with default panel configurations.
+    ///
+    /// Initializes both the Do and Don't panels with Swift as the default
+    /// language and empty code content. Panel titles are read from
+    /// `@AppStorage` in the views.
     public init() {
         // Read titles from UserDefaults directly for initialization
         doPanel = CodePanel(type: .doPanel)
@@ -51,13 +112,32 @@ public final class AppViewModel {
 
     // MARK: - Language Management
 
-    /// Updates the language for both panels
+    /// Updates the syntax highlighting language for both panels.
+    ///
+    /// Call this method when the user selects a different programming
+    /// language from the toolbar picker. Both panels are updated
+    /// simultaneously to maintain consistency.
+    ///
+    /// - Parameter language: The new programming language for syntax highlighting.
+    ///
+    /// ```swift
+    /// viewModel.setLanguage(.python)
+    /// viewModel.setLanguage(.javascript)
+    /// ```
     public func setLanguage(_ language: CodeLanguage) {
         doPanel.language = language
         dontPanel.language = language
     }
-    
-    /// Updates the language for both panels
+
+    /// Updates the titles for both code panels.
+    ///
+    /// Panel titles are displayed in the title bar above each code editor.
+    /// This method synchronizes the view model's panels with the titles
+    /// stored in `@AppStorage`.
+    ///
+    /// - Parameters:
+    ///   - doTitle: The title for the "Do's" panel.
+    ///   - dontTitle: The title for the "Don'ts" panel.
     public func update(doTitle: String, dontTitle: String) {
         doPanel.title = doTitle
         dontPanel.title = dontTitle
@@ -103,9 +183,35 @@ public final class AppViewModel {
 
 // MARK: - Errors
 
+/// Errors that can occur during image export operations.
+///
+/// These errors are thrown by ``AppViewModel/saveImage(_:)`` when
+/// export operations fail. Each case provides a user-friendly
+/// error description via `LocalizedError`.
+///
+/// ## Topics
+///
+/// ### Error Cases
+///
+/// - ``conversionFailed``
+/// - ``saveFailed``
+/// - ``accessDenied``
 public enum ExportError: LocalizedError {
+    /// The image could not be converted to PNG format.
+    ///
+    /// This typically occurs if the `NSImage` has invalid or
+    /// unsupported image data.
     case conversionFailed
+
+    /// The PNG data could not be written to disk.
+    ///
+    /// This may occur due to disk space issues or file system errors.
     case saveFailed
+
+    /// The save location cannot be accessed.
+    ///
+    /// This occurs when the security-scoped bookmark is stale or invalid.
+    /// The user should choose a new save location via the "Choose" button.
     case accessDenied
 
     public var errorDescription: String? {

--- a/BifcodePackage/Sources/BifcodeFeature/Views/CodeEditorView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/CodeEditorView.swift
@@ -10,9 +10,58 @@ import CodeEditLanguages
 import CodeEditSourceEditor
 import SwiftUI
 
-/// A complete code editor panel with title bar, syntax highlighting editor, and Do/Don't indicator
+/// A complete code editor panel with title bar, syntax highlighting, and indicator badge.
+///
+/// `CodeEditorView` is the main interactive component for editing code in Bifcode.
+/// It combines a title bar, CodeEditSourceEditor for syntax highlighting, and an
+/// ``IndicatorBadgeView`` to show the "Do" or "Don't" designation.
+///
+/// ## Overview
+///
+/// Each panel consists of three visual layers:
+/// 1. **Title Bar** - Shows the panel title with a document icon
+/// 2. **Code Editor** - Syntax-highlighted code using `SourceEditor`
+/// 3. **Indicator Badge** - Positioned "Do" or "Don't" badge
+///
+/// ## Code Limits
+///
+/// The editor enforces limits to ensure exported images remain readable:
+/// - Maximum 24 lines of code
+/// - Maximum 210 characters per line
+///
+/// ## Settings Integration
+///
+/// The view reads settings directly from `@AppStorage`:
+/// - Indicator position, style, size, icons, and labels
+/// - Font size and theme
+/// - Title visibility
+///
+/// ## Usage
+///
+/// ```swift
+/// @Bindable var panel: CodePanel
+///
+/// CodeEditorView(panel: panel) {
+///     // Called when code changes
+///     print("Code updated: \(panel.code)")
+/// }
+/// ```
+///
+/// ## Topics
+///
+/// ### Creating an Editor
+///
+/// - ``init(panel:onCodeChange:)``
+///
+/// ### Related Types
+///
+/// - ``CodePanel``
+/// - ``IndicatorBadgeView``
 public struct CodeEditorView: View {
+    /// The code panel model containing the code, title, and language.
     @Bindable var panel: CodePanel
+
+    /// Callback invoked when the code content changes.
     let onCodeChange: () -> Void
 
     // MARK: - Settings (via @AppStorage)
@@ -40,6 +89,18 @@ public struct CodeEditorView: View {
         EditorThemeOption(rawValue: selectedThemeRaw) ?? .atomOneDark
     }
 
+    /// Creates a new code editor view for the specified panel.
+    ///
+    /// - Parameters:
+    ///   - panel: The ``CodePanel`` model to display and edit.
+    ///   - onCodeChange: A closure called whenever the code content changes.
+    ///     Defaults to an empty closure.
+    ///
+    /// ```swift
+    /// CodeEditorView(panel: viewModel.doPanel) {
+    ///     updateExportPreview()
+    /// }
+    /// ```
     public init(
         panel: CodePanel,
         onCodeChange: @escaping () -> Void = {}

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ExportPanelView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ExportPanelView.swift
@@ -10,20 +10,60 @@ import CodeEditLanguages
 import CodeEditSourceEditor
 import SwiftUI
 
-/// Static code panel view for ImageRenderer export
-/// Uses SourceEditor with same settings as CodeEditorView for consistent rendering
+/// A static, non-interactive code panel for export rendering.
+///
+/// `ExportPanelView` renders a single code panel with syntax highlighting
+/// and indicator badge for image export. Unlike ``CodeEditorView``, this
+/// view is disabled (non-interactive) and designed for offscreen rendering.
+///
+/// ## Overview
+///
+/// The export panel maintains visual consistency with the interactive
+/// ``CodeEditorView`` by using the same:
+/// - `SourceEditor` configuration
+/// - Title bar styling
+/// - Indicator badge positioning
+/// - Color theming
+///
+/// ## Differences from CodeEditorView
+///
+/// | Aspect | CodeEditorView | ExportPanelView |
+/// |--------|---------------|-----------------|
+/// | Interactive | Yes | No (disabled) |
+/// | @AppStorage | Reads settings | Receives as params |
+/// | Editor state | Shared | Local |
+/// | Purpose | User editing | Image export |
+///
+/// > Note: This is an internal view and not part of the public API.
 struct ExportPanelView: View {
+    /// The code panel to render.
     @Bindable var panel: CodePanel
+
+    /// Position of the indicator badge.
     let indicatorPosition: IndicatorPosition
+
+    /// Style of the indicator badge.
     let indicatorStyle: IndicatorStyle
+
+    /// Size of the indicator badge in points.
     let indicatorSize: CGFloat
+
+    /// SF Symbol name for the indicator icon.
     let indicatorIconName: String
+
+    /// Text label for the indicator.
     let indicatorLabel: String
+
+    /// Whether to show the title bar.
     let showTitle: Bool
+
+    /// Font size for code text.
     let fontSize: CGFloat
+
+    /// The syntax highlighting theme.
     let theme: EditorTheme
 
-    /// Editor state for the source editor
+    /// Local editor state (not shared with interactive editor).
     @State private var editorState = SourceEditorState()
 
     // MARK: - Body

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ExportView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ExportView.swift
@@ -9,26 +9,72 @@ import AppKit
 import CodeEditSourceEditor
 import SwiftUI
 
-/// Combined export view with both panels for ImageRenderer
-/// This view is used exclusively for generating the export image
+/// A container view arranging both code panels for image export.
+///
+/// `ExportView` arranges the Do and Don't ``ExportPanelView`` instances
+/// either horizontally or vertically based on the layout setting. This view
+/// is used exclusively for generating the export image—it's rendered
+/// offscreen and captured as a bitmap.
+///
+/// ## Overview
+///
+/// The export view:
+/// - Arranges panels based on ``WindowLayout`` (horizontal or vertical)
+/// - Applies consistent padding (24pt) and spacing (24pt)
+/// - Adds drop shadows to each panel
+/// - Uses a transparent background for the final image
+///
+/// > Note: This is an internal view and not part of the public API.
+/// > It's created by ``ContentView/renderExportViewToImage()`` during export.
 struct ExportView: View {
+    /// The "Do's" code panel to export.
     let doPanel: CodePanel
+
+    /// The "Don'ts" code panel to export.
     let dontPanel: CodePanel
+
+    /// The panel arrangement (horizontal or vertical).
     let layout: WindowLayout
+
+    /// Position of the indicator badge.
     let indicatorPosition: IndicatorPosition
+
+    /// Style of the indicator badge.
     let indicatorStyle: IndicatorStyle
+
+    /// Size of the indicator badge in points.
     let indicatorSize: CGFloat
+
+    /// SF Symbol name for the Do badge.
     let doIndicatorIcon: String
+
+    /// SF Symbol name for the Don't badge.
     let dontIndicatorIcon: String
+
+    /// Text label for the Do badge.
     let doIndicatorLabel: String
+
+    /// Text label for the Don't badge.
     let dontIndicatorLabel: String
+
+    /// Whether to show the title bar on panels.
     let showTitle: Bool
+
+    /// Font size for code text.
     let fontSize: CGFloat
+
+    /// The syntax highlighting theme.
     let theme: EditorTheme
 
     // Panel dimensions for export
+
+    /// Width of each panel in points.
     let panelWidth: CGFloat
+
+    /// Height of the Do panel in points.
     let doPanelHeight: CGFloat
+
+    /// Height of the Don't panel in points.
     let dontPanelHeight: CGFloat
 
     var body: some View {

--- a/BifcodePackage/Sources/BifcodeFeature/Views/IndicatorBadgeView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/IndicatorBadgeView.swift
@@ -7,14 +7,80 @@
 
 import SwiftUI
 
-/// Do/Don't indicator badge
+/// A visual badge indicating whether a code panel shows "Do" or "Don't" examples.
+///
+/// `IndicatorBadgeView` displays an icon, text label, or both to clearly mark
+/// code panels as positive (Do) or negative (Don't) examples. The badge uses
+/// semantic colors from the app's color system.
+///
+/// ## Overview
+///
+/// The badge appearance is controlled by three main factors:
+/// - **Type** - Determines color (green for Do, red for Don't)
+/// - **Style** - Shows icon only, text only, or both
+/// - **Size** - Controls overall badge dimensions
+///
+/// ## Sizing
+///
+/// Badge elements scale proportionally to the `size` parameter:
+/// - Icon: 60% of size
+/// - Text: 30% of size
+///
+/// ## Usage
+///
+/// ```swift
+/// // Icon and text badge for "Do" panel
+/// IndicatorBadgeView(
+///     type: .doPanel,
+///     style: .iconAndText,
+///     size: 48
+/// )
+///
+/// // Custom icon badge for "Don't" panel
+/// IndicatorBadgeView(
+///     type: .dontPanel,
+///     style: .iconOnly,
+///     size: 64,
+///     iconName: "exclamationmark.triangle"
+/// )
+/// ```
+///
+/// ## Topics
+///
+/// ### Creating a Badge
+///
+/// - ``init(type:style:size:iconName:label:)``
+///
+/// ### Related Types
+///
+/// - ``PanelType``
+/// - ``IndicatorStyle``
+/// - ``IndicatorIcon``
 public struct IndicatorBadgeView: View {
+    /// The panel type determining the badge color (Do = green, Don't = red).
     let type: PanelType
+
+    /// The display style controlling which elements are shown.
     let style: IndicatorStyle
+
+    /// The overall size of the badge in points.
     let size: CGFloat
+
+    /// The SF Symbol name for the icon.
     let iconName: String
+
+    /// The text label displayed below the icon.
     let label: String
 
+    /// Creates a new indicator badge with the specified configuration.
+    ///
+    /// - Parameters:
+    ///   - type: The panel type (Do or Don't) determining the badge color.
+    ///   - style: The display style (icon only, text only, or both).
+    ///   - size: The overall badge size in points.
+    ///   - iconName: The SF Symbol name. Defaults to "checkmark" for Do,
+    ///     "xmark" for Don't.
+    ///   - label: The text label. Defaults to "Do's" or "Don'ts".
     public init(
         type: PanelType,
         style: IndicatorStyle,

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
@@ -9,7 +9,42 @@ import CodeEditLanguages
 import CodeEditSourceEditor
 import SwiftUI
 
-/// Toolbar view with all settings inline
+/// A toolbar providing all code style and indicator settings with an export button.
+///
+/// `ToolBarView` is the main settings interface for Bifcode. It presents controls
+/// organized into sections for code style, indicator customization, and export.
+///
+/// ## Overview
+///
+/// The toolbar contains three main sections:
+///
+/// ### Code Style Section
+/// - **Language Picker** - Select from 19 programming languages
+/// - **Theme Picker** - Choose from 7 syntax highlighting themes
+/// - **Layout Toggle** - Switch between horizontal and vertical layouts
+/// - **Font Size Slider** - Adjust code font (10-24pt)
+/// - **Panel Titles** - Edit "Do" and "Don't" panel titles
+///
+/// ### Indicator Style Section
+/// - **Style Picker** - Icon only, text only, or both
+/// - **Position Picker** - Top-right or bottom-right
+/// - **Size Slider** - Badge size (32-80px)
+/// - **Icon Pickers** - Choose icons for Do/Don't badges
+/// - **Label Fields** - Custom text for indicator labels
+///
+/// ### Export Section
+/// - **Export Button** - Save as PNG (disabled when panels are empty)
+/// - **Choose Button** - Select save location folder
+///
+/// ## Settings Persistence
+///
+/// All settings are automatically persisted via `@AppStorage` to UserDefaults.
+///
+/// ## Topics
+///
+/// ### Creating a Toolbar
+///
+/// - ``init(doTitleSetting:dontTitleSetting:isExportDisabled:onExport:onLanguageChange:)``
 public struct ToolBarView: View {
     // MARK: - App Storage
 
@@ -47,6 +82,26 @@ public struct ToolBarView: View {
 
     // MARK: - Initialization
 
+    /// Creates a new toolbar view with the specified configuration.
+    ///
+    /// - Parameters:
+    ///   - doTitleSetting: Binding to the "Do's" panel title.
+    ///   - dontTitleSetting: Binding to the "Don'ts" panel title.
+    ///   - isExportDisabled: Whether the export button should be disabled.
+    ///     Set to `true` when both code panels are empty.
+    ///   - onExport: Closure called when the export button is tapped.
+    ///   - onLanguageChange: Closure called when the language selection changes,
+    ///     providing the newly selected ``CodeLanguage``.
+    ///
+    /// ```swift
+    /// ToolBarView(
+    ///     doTitleSetting: $doTitle,
+    ///     dontTitleSetting: $dontTitle,
+    ///     isExportDisabled: viewModel.doPanel.code.isEmpty,
+    ///     onExport: { Task { await exportImage() } },
+    ///     onLanguageChange: { viewModel.setLanguage($0) }
+    /// )
+    /// ```
     public init(
         doTitleSetting: Binding<String>,
         dontTitleSetting: Binding<String>,


### PR DESCRIPTION
## Summary

Adds comprehensive DocC documentation to all Bifcode source files, including detailed API documentation, usage examples, and a complete DocC catalog with architecture overview and getting started guide.

## Changes

- **DocC Catalog**: Created BifcodeFeature.docc with main landing page, getting started tutorial, and architecture overview
- **ViewModels**: Documented AppViewModel with state management, error handling, and export workflow
- **Models**: Added documentation for CodePanel, PanelType, and all SettingsTypes enums
- **Views**: Comprehensive documentation for ContentView, CodeEditorView, ToolBarView, IndicatorBadgeView, and export views
- **Services**: Documented BookmarkManager security-scoped bookmark workflow
- **Extensions**: Added semantic color categories and usage patterns

## Quality

All documentation follows DocC best practices with code examples, property descriptions, and cross-references using \`\`TypeName\`\` syntax.