### PR TITLE
test: add comprehensive test suite with 208 tests

### DIFF
--- a/BifcodePackage/Tests/BifcodeFeatureTests/AppViewModelTests.swift
+++ b/BifcodePackage/Tests/BifcodeFeatureTests/AppViewModelTests.swift
@@ -1,0 +1,452 @@
+//
+//  AppViewModelTests.swift
+//
+//  Created on 18.12.2025.
+//  Copyright © 2025 IGR Soft. All rights reserved.
+//
+
+import CodeEditLanguages
+import Foundation
+import Testing
+@testable import BifcodeFeature
+
+// MARK: - AppViewModel Tests
+
+@Suite("AppViewModel Tests")
+@MainActor
+struct AppViewModelTests {
+    // MARK: - Initialization
+
+    @Test("init creates doPanel with doPanel type")
+    func initCreatesDoPanelWithCorrectType() {
+        let viewModel = AppViewModel()
+
+        #expect(viewModel.doPanel.type == .doPanel)
+    }
+
+    @Test("init creates dontPanel with dontPanel type")
+    func initCreatesDontPanelWithCorrectType() {
+        let viewModel = AppViewModel()
+
+        #expect(viewModel.dontPanel.type == .dontPanel)
+    }
+
+    @Test("init creates panels with empty code")
+    func initCreatesPanelsWithEmptyCode() {
+        let viewModel = AppViewModel()
+
+        #expect(viewModel.doPanel.code.isEmpty)
+        #expect(viewModel.dontPanel.code.isEmpty)
+    }
+
+    @Test("init creates panels with default Swift language")
+    func initCreatesPanelsWithSwiftLanguage() {
+        let viewModel = AppViewModel()
+
+        #expect(viewModel.doPanel.language == .swift)
+        #expect(viewModel.dontPanel.language == .swift)
+    }
+
+    @Test("init creates distinct panels")
+    func initCreatesDistinctPanels() {
+        let viewModel = AppViewModel()
+
+        #expect(viewModel.doPanel.id != viewModel.dontPanel.id)
+    }
+
+    // MARK: - setLanguage
+
+    @Test("setLanguage updates doPanel language")
+    func setLanguageUpdatesDoPanelLanguage() {
+        let viewModel = AppViewModel()
+
+        viewModel.setLanguage(.python)
+
+        #expect(viewModel.doPanel.language == .python)
+    }
+
+    @Test("setLanguage updates dontPanel language")
+    func setLanguageUpdatesDontPanelLanguage() {
+        let viewModel = AppViewModel()
+
+        viewModel.setLanguage(.python)
+
+        #expect(viewModel.dontPanel.language == .python)
+    }
+
+    @Test("setLanguage updates both panels simultaneously")
+    func setLanguageUpdatesBothPanels() {
+        let viewModel = AppViewModel()
+
+        viewModel.setLanguage(.javascript)
+
+        #expect(viewModel.doPanel.language == .javascript)
+        #expect(viewModel.dontPanel.language == .javascript)
+    }
+
+    @Test("setLanguage can be called multiple times")
+    func setLanguageMultipleTimes() {
+        let viewModel = AppViewModel()
+
+        viewModel.setLanguage(.python)
+        #expect(viewModel.doPanel.language == .python)
+
+        viewModel.setLanguage(.rust)
+        #expect(viewModel.doPanel.language == .rust)
+
+        viewModel.setLanguage(.swift)
+        #expect(viewModel.doPanel.language == .swift)
+    }
+
+    @Test("setLanguage supports common programming languages")
+    func setLanguageSupportsCommonLanguages() {
+        let viewModel = AppViewModel()
+        let languages: [CodeLanguage] = [
+            .swift, .python, .javascript, .typescript,
+            .java, .kotlin, .rust, .go, .c, .cpp
+        ]
+
+        for language in languages {
+            viewModel.setLanguage(language)
+            #expect(viewModel.doPanel.language == language)
+            #expect(viewModel.dontPanel.language == language)
+        }
+    }
+
+    @Test("setLanguage does not affect panel code")
+    func setLanguageDoesNotAffectCode() {
+        let viewModel = AppViewModel()
+        viewModel.doPanel.code = "let x = 1"
+        viewModel.dontPanel.code = "let y = 2"
+
+        viewModel.setLanguage(.python)
+
+        #expect(viewModel.doPanel.code == "let x = 1")
+        #expect(viewModel.dontPanel.code == "let y = 2")
+    }
+
+    @Test("setLanguage does not affect panel titles")
+    func setLanguageDoesNotAffectTitles() {
+        let viewModel = AppViewModel()
+        viewModel.doPanel.title = "Do Title"
+        viewModel.dontPanel.title = "Dont Title"
+
+        viewModel.setLanguage(.python)
+
+        #expect(viewModel.doPanel.title == "Do Title")
+        #expect(viewModel.dontPanel.title == "Dont Title")
+    }
+
+    // MARK: - update(doTitle:dontTitle:)
+
+    @Test("update updates doPanel title")
+    func updateUpdatesDoPanelTitle() {
+        let viewModel = AppViewModel()
+
+        viewModel.update(doTitle: "New Do Title", dontTitle: "New Dont Title")
+
+        #expect(viewModel.doPanel.title == "New Do Title")
+    }
+
+    @Test("update updates dontPanel title")
+    func updateUpdatesDontPanelTitle() {
+        let viewModel = AppViewModel()
+
+        viewModel.update(doTitle: "New Do Title", dontTitle: "New Dont Title")
+
+        #expect(viewModel.dontPanel.title == "New Dont Title")
+    }
+
+    @Test("update can set empty titles")
+    func updateCanSetEmptyTitles() {
+        let viewModel = AppViewModel()
+        viewModel.doPanel.title = "Existing"
+        viewModel.dontPanel.title = "Existing"
+
+        viewModel.update(doTitle: "", dontTitle: "")
+
+        #expect(viewModel.doPanel.title.isEmpty)
+        #expect(viewModel.dontPanel.title.isEmpty)
+    }
+
+    @Test("update can set long titles")
+    func updateCanSetLongTitles() {
+        let viewModel = AppViewModel()
+        let longTitle = String(repeating: "A", count: 100)
+
+        viewModel.update(doTitle: longTitle, dontTitle: longTitle)
+
+        #expect(viewModel.doPanel.title == longTitle)
+        #expect(viewModel.dontPanel.title == longTitle)
+    }
+
+    @Test("update can set titles with special characters")
+    func updateCanSetTitlesWithSpecialCharacters() {
+        let viewModel = AppViewModel()
+
+        viewModel.update(doTitle: "Title with 🎉 emoji", dontTitle: "Title & <special> chars")
+
+        #expect(viewModel.doPanel.title == "Title with 🎉 emoji")
+        #expect(viewModel.dontPanel.title == "Title & <special> chars")
+    }
+
+    @Test("update does not affect panel code")
+    func updateDoesNotAffectCode() {
+        let viewModel = AppViewModel()
+        viewModel.doPanel.code = "let x = 1"
+        viewModel.dontPanel.code = "let y = 2"
+
+        viewModel.update(doTitle: "New Title", dontTitle: "New Title")
+
+        #expect(viewModel.doPanel.code == "let x = 1")
+        #expect(viewModel.dontPanel.code == "let y = 2")
+    }
+
+    @Test("update does not affect panel language")
+    func updateDoesNotAffectLanguage() {
+        let viewModel = AppViewModel()
+        viewModel.setLanguage(.python)
+
+        viewModel.update(doTitle: "New Title", dontTitle: "New Title")
+
+        #expect(viewModel.doPanel.language == .python)
+        #expect(viewModel.dontPanel.language == .python)
+    }
+
+    // MARK: - Save Location
+
+    @Test("saveLocation returns a valid URL")
+    func saveLocationReturnsValidURL() {
+        let viewModel = AppViewModel()
+
+        let location = viewModel.saveLocation
+
+        #expect(location.isFileURL)
+    }
+
+    @Test("saveLocation defaults to Desktop when no bookmark")
+    func saveLocationDefaultsToDesktop() {
+        // Clear any existing bookmark first
+        BookmarkManager.shared.clearBookmark()
+
+        let viewModel = AppViewModel()
+        let location = viewModel.saveLocation
+
+        // Should contain Desktop in path
+        #expect(location.path.contains("Desktop"))
+    }
+
+    @Test("saveLocationName returns 'Desktop' by default")
+    func saveLocationNameDefault() {
+        BookmarkManager.shared.clearBookmark()
+
+        let viewModel = AppViewModel()
+
+        #expect(viewModel.saveLocationName == "Desktop")
+    }
+
+    @Test("hasCustomSaveLocation is false when no bookmark")
+    func hasCustomSaveLocationFalseByDefault() {
+        BookmarkManager.shared.clearBookmark()
+
+        let viewModel = AppViewModel()
+
+        #expect(viewModel.hasCustomSaveLocation == false)
+    }
+
+    // MARK: - Panel Independence
+
+    @Test("modifying doPanel code does not affect dontPanel")
+    func doPanelCodeIndependent() {
+        let viewModel = AppViewModel()
+
+        viewModel.doPanel.code = "modified"
+
+        #expect(viewModel.dontPanel.code.isEmpty)
+    }
+
+    @Test("modifying dontPanel code does not affect doPanel")
+    func dontPanelCodeIndependent() {
+        let viewModel = AppViewModel()
+
+        viewModel.dontPanel.code = "modified"
+
+        #expect(viewModel.doPanel.code.isEmpty)
+    }
+
+    @Test("panels have independent titles when set individually")
+    func panelTitlesIndependent() {
+        let viewModel = AppViewModel()
+
+        viewModel.doPanel.title = "Do Title Only"
+
+        #expect(viewModel.doPanel.title == "Do Title Only")
+        #expect(viewModel.dontPanel.title.isEmpty)
+    }
+
+    // MARK: - Observable Behavior
+
+    @Test("panels are accessible properties")
+    func panelsAccessible() {
+        let viewModel = AppViewModel()
+
+        // Verify panels are publicly accessible
+        let _: CodePanel = viewModel.doPanel
+        let _: CodePanel = viewModel.dontPanel
+    }
+
+    // MARK: - Multiple ViewModel Instances
+
+    @Test("multiple viewModel instances are independent")
+    func multipleInstancesIndependent() {
+        let viewModel1 = AppViewModel()
+        let viewModel2 = AppViewModel()
+
+        viewModel1.doPanel.code = "Code 1"
+        viewModel2.doPanel.code = "Code 2"
+        viewModel1.setLanguage(.python)
+
+        #expect(viewModel1.doPanel.code == "Code 1")
+        #expect(viewModel2.doPanel.code == "Code 2")
+        #expect(viewModel1.doPanel.language == .python)
+        #expect(viewModel2.doPanel.language == .swift)
+    }
+}
+
+// MARK: - ExportError Tests
+
+@Suite("ExportError Tests")
+struct ExportErrorTests {
+    // MARK: - Error Cases
+
+    @Test("conversionFailed is a valid case")
+    func conversionFailedCase() {
+        let error = ExportError.conversionFailed
+        #expect(error == .conversionFailed)
+    }
+
+    @Test("saveFailed is a valid case")
+    func saveFailedCase() {
+        let error = ExportError.saveFailed
+        #expect(error == .saveFailed)
+    }
+
+    @Test("accessDenied is a valid case")
+    func accessDeniedCase() {
+        let error = ExportError.accessDenied
+        #expect(error == .accessDenied)
+    }
+
+    // MARK: - Error Descriptions
+
+    @Test("conversionFailed has correct error description")
+    func conversionFailedDescription() {
+        let error = ExportError.conversionFailed
+
+        #expect(error.errorDescription == "Failed to convert image to PNG")
+    }
+
+    @Test("saveFailed has correct error description")
+    func saveFailedDescription() {
+        let error = ExportError.saveFailed
+
+        #expect(error.errorDescription == "Failed to save image")
+    }
+
+    @Test("accessDenied has correct error description")
+    func accessDeniedDescription() {
+        let error = ExportError.accessDenied
+
+        #expect(error.errorDescription == "Cannot access save location. Please choose a new folder.")
+    }
+
+    // MARK: - LocalizedError Conformance
+
+    @Test("ExportError conforms to LocalizedError")
+    func localizedErrorConformance() {
+        let error: any LocalizedError = ExportError.conversionFailed
+
+        #expect(error.errorDescription != nil)
+    }
+
+    @Test("all error descriptions are non-empty")
+    func allDescriptionsNonEmpty() {
+        let errors: [ExportError] = [.conversionFailed, .saveFailed, .accessDenied]
+
+        for error in errors {
+            #expect(error.errorDescription?.isEmpty == false)
+        }
+    }
+
+    // MARK: - Equality
+
+    @Test("same error cases are equal")
+    func sameErrorCasesEqual() {
+        #expect(ExportError.conversionFailed == ExportError.conversionFailed)
+        #expect(ExportError.saveFailed == ExportError.saveFailed)
+        #expect(ExportError.accessDenied == ExportError.accessDenied)
+    }
+
+    @Test("different error cases are not equal")
+    func differentErrorCasesNotEqual() {
+        #expect(ExportError.conversionFailed != ExportError.saveFailed)
+        #expect(ExportError.saveFailed != ExportError.accessDenied)
+        #expect(ExportError.accessDenied != ExportError.conversionFailed)
+    }
+
+    // MARK: - Error can be thrown
+
+    @Test("conversionFailed can be thrown and caught")
+    func conversionFailedCanBeThrown() async {
+        func throwingFunction() throws {
+            throw ExportError.conversionFailed
+        }
+
+        var caughtError: ExportError?
+        do {
+            try throwingFunction()
+        } catch let error as ExportError {
+            caughtError = error
+        } catch {
+            // Other error type
+        }
+
+        #expect(caughtError == .conversionFailed)
+    }
+
+    @Test("saveFailed can be thrown and caught")
+    func saveFailedCanBeThrown() async {
+        func throwingFunction() throws {
+            throw ExportError.saveFailed
+        }
+
+        var caughtError: ExportError?
+        do {
+            try throwingFunction()
+        } catch let error as ExportError {
+            caughtError = error
+        } catch {
+            // Other error type
+        }
+
+        #expect(caughtError == .saveFailed)
+    }
+
+    @Test("accessDenied can be thrown and caught")
+    func accessDeniedCanBeThrown() async {
+        func throwingFunction() throws {
+            throw ExportError.accessDenied
+        }
+
+        var caughtError: ExportError?
+        do {
+            try throwingFunction()
+        } catch let error as ExportError {
+            caughtError = error
+        } catch {
+            // Other error type
+        }
+
+        #expect(caughtError == .accessDenied)
+    }
+}

--- a/BifcodePackage/Tests/BifcodeFeatureTests/BifcodeFeatureTests.swift
+++ b/BifcodePackage/Tests/BifcodeFeatureTests/BifcodeFeatureTests.swift
@@ -5,10 +5,240 @@
 //  Copyright © 2025 IGR Soft. All rights reserved.
 //
 
+import CodeEditLanguages
 import Testing
 @testable import BifcodeFeature
 
-@Test
-func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+// MARK: - Module Import Tests
+
+@Suite("BifcodeFeature Module Tests")
+struct BifcodeFeatureModuleTests {
+    @Test("BifcodeFeature module imports successfully")
+    func moduleImports() {
+        // If this test runs, the module is importable
+        #expect(true)
+    }
+
+    @Test("All public types are accessible")
+    func publicTypesAccessible() {
+        // Models
+        _ = PanelType.doPanel
+        _ = IndicatorPosition.topRight
+        _ = IndicatorStyle.iconAndText
+        _ = IndicatorIcon.checkmark
+        _ = WindowLayout.horizontal
+        _ = EditorThemeOption.atomOneDark
+
+        // Errors
+        _ = ExportError.conversionFailed
+
+        #expect(true)
+    }
+
+    @Test("All enum allCases are accessible")
+    func allCasesAccessible() {
+        #expect(!IndicatorPosition.allCases.isEmpty)
+        #expect(!IndicatorStyle.allCases.isEmpty)
+        #expect(!IndicatorIcon.allCases.isEmpty)
+        #expect(!WindowLayout.allCases.isEmpty)
+        #expect(!EditorThemeOption.allCases.isEmpty)
+    }
+}
+
+// MARK: - Edge Case Tests
+
+@Suite("Edge Case Tests")
+@MainActor
+struct EdgeCaseTests {
+    // MARK: - Empty String Handling
+
+    @Test("CodePanel handles empty code")
+    func emptyCodeHandling() {
+        let panel = CodePanel(type: .doPanel)
+
+        #expect(panel.code.isEmpty)
+        panel.code = ""
+        #expect(panel.code.isEmpty)
+    }
+
+    @Test("CodePanel handles empty title")
+    func emptyTitleHandling() {
+        let panel = CodePanel(type: .doPanel, title: "")
+
+        #expect(panel.title.isEmpty)
+    }
+
+    @Test("AppViewModel handles empty titles in update")
+    func emptyTitlesInUpdate() {
+        let viewModel = AppViewModel()
+        viewModel.update(doTitle: "", dontTitle: "")
+
+        #expect(viewModel.doPanel.title.isEmpty)
+        #expect(viewModel.dontPanel.title.isEmpty)
+    }
+
+    // MARK: - Unicode and Special Characters
+
+    @Test("CodePanel handles unicode in code")
+    func unicodeInCode() {
+        let panel = CodePanel(type: .doPanel)
+        panel.code = "let greeting = \"こんにちは\""
+
+        #expect(panel.code.contains("こんにちは"))
+    }
+
+    @Test("CodePanel handles emoji in code")
+    func emojiInCode() {
+        let panel = CodePanel(type: .doPanel)
+        panel.code = "let emoji = \"🎉🚀💻\""
+
+        #expect(panel.code.contains("🎉"))
+        #expect(panel.code.contains("🚀"))
+        #expect(panel.code.contains("💻"))
+    }
+
+    @Test("CodePanel handles unicode in title")
+    func unicodeInTitle() {
+        let panel = CodePanel(type: .doPanel, title: "例: 日本語タイトル")
+
+        #expect(panel.title.contains("日本語"))
+    }
+
+    @Test("AppViewModel handles unicode in titles")
+    func unicodeInTitles() {
+        let viewModel = AppViewModel()
+        viewModel.update(doTitle: "做正確的事", dontTitle: "避免這個")
+
+        #expect(viewModel.doPanel.title == "做正確的事")
+        #expect(viewModel.dontPanel.title == "避免這個")
+    }
+
+    // MARK: - Whitespace Handling
+
+    @Test("CodePanel preserves leading/trailing whitespace in code")
+    func whitespaceInCode() {
+        let panel = CodePanel(type: .doPanel)
+        panel.code = "  let x = 1  "
+
+        #expect(panel.code.hasPrefix("  "))
+        #expect(panel.code.hasSuffix("  "))
+    }
+
+    @Test("CodePanel preserves newlines in code")
+    func newlinesInCode() {
+        let panel = CodePanel(type: .doPanel)
+        panel.code = "line1\nline2\nline3"
+
+        let lines = panel.code.components(separatedBy: "\n")
+        #expect(lines.count == 3)
+    }
+
+    @Test("CodePanel preserves tabs in code")
+    func tabsInCode() {
+        let panel = CodePanel(type: .doPanel)
+        panel.code = "func test() {\n\tlet x = 1\n}"
+
+        #expect(panel.code.contains("\t"))
+    }
+
+    // MARK: - Boundary Values
+
+    @Test("IndicatorIcon collections have no overlap")
+    func iconCollectionsNoOverlap() {
+        let positiveSet = Set(IndicatorIcon.positiveIcons)
+        let negativeSet = Set(IndicatorIcon.negativeIcons)
+
+        let intersection = positiveSet.intersection(negativeSet)
+        #expect(intersection.isEmpty)
+    }
+
+    @Test("All IndicatorIcon cases are in either positive or negative")
+    func allIconsCategorized() {
+        let allSet = Set(IndicatorIcon.allCases)
+        let positiveSet = Set(IndicatorIcon.positiveIcons)
+        let negativeSet = Set(IndicatorIcon.negativeIcons)
+
+        #expect(allSet == positiveSet.union(negativeSet))
+    }
+
+    // MARK: - State Consistency
+
+    @Test("CodePanel type is immutable")
+    func panelTypeImmutable() {
+        let doPanel = CodePanel(type: .doPanel)
+        let dontPanel = CodePanel(type: .dontPanel)
+
+        // Type should not change regardless of other property changes
+        doPanel.code = "test"
+        doPanel.title = "test"
+
+        #expect(doPanel.type == .doPanel)
+        #expect(dontPanel.type == .dontPanel)
+    }
+
+    @Test("AppViewModel panels are distinct objects")
+    func viewModelPanelsDistinct() {
+        let viewModel = AppViewModel()
+
+        // Verify they are different objects
+        viewModel.doPanel.code = "do code"
+        #expect(viewModel.dontPanel.code != "do code")
+
+        viewModel.dontPanel.title = "dont title"
+        #expect(viewModel.doPanel.title != "dont title")
+    }
+}
+
+// MARK: - Performance Characteristic Tests
+
+@Suite("Performance Characteristic Tests")
+@MainActor
+struct PerformanceTests {
+    @Test("Large code content handling")
+    func largeCodeContent() {
+        let panel = CodePanel(type: .doPanel)
+
+        // Create a large code string (1000 lines)
+        let largeCode = (1 ... 1000).map { "let line\($0) = \($0)" }.joined(separator: "\n")
+        panel.code = largeCode
+
+        // Should handle without issues
+        #expect(panel.code.contains("line1"))
+        #expect(panel.code.contains("line500"))
+        #expect(panel.code.contains("line1000"))
+    }
+
+    @Test("Rapid language changes")
+    func rapidLanguageChanges() {
+        let viewModel = AppViewModel()
+        let languages: [CodeLanguage] = [
+            .swift, .python, .javascript, .typescript, .java,
+            .kotlin, .rust, .go, .c, .cpp
+        ]
+
+        // Rapidly change languages
+        for _ in 1 ... 100 {
+            for language in languages {
+                viewModel.setLanguage(language)
+            }
+        }
+
+        // Final state should be consistent
+        #expect(viewModel.doPanel.language == .cpp)
+        #expect(viewModel.dontPanel.language == .cpp)
+    }
+
+    @Test("Rapid title updates")
+    func rapidTitleUpdates() {
+        let viewModel = AppViewModel()
+
+        // Rapidly update titles
+        for i in 1 ... 100 {
+            viewModel.update(doTitle: "Do \(i)", dontTitle: "Dont \(i)")
+        }
+
+        // Final state should be consistent
+        #expect(viewModel.doPanel.title == "Do 100")
+        #expect(viewModel.dontPanel.title == "Dont 100")
+    }
 }

--- a/BifcodePackage/Tests/BifcodeFeatureTests/BookmarkManagerTests.swift
+++ b/BifcodePackage/Tests/BifcodeFeatureTests/BookmarkManagerTests.swift
@@ -1,0 +1,252 @@
+//
+//  BookmarkManagerTests.swift
+//
+//  Created on 18.12.2025.
+//  Copyright © 2025 IGR Soft. All rights reserved.
+//
+
+import Foundation
+import Testing
+@testable import BifcodeFeature
+
+// MARK: - BookmarkManager Tests
+
+@Suite("BookmarkManager Tests")
+@MainActor
+struct BookmarkManagerTests {
+    // MARK: - Setup/Teardown
+
+    init() {
+        // Clear any existing bookmark before each test
+        BookmarkManager.shared.clearBookmark()
+    }
+
+    // MARK: - Singleton
+
+    @Test("shared returns singleton instance")
+    func sharedReturnsSingleton() {
+        let instance1 = BookmarkManager.shared
+        let instance2 = BookmarkManager.shared
+
+        #expect(instance1 === instance2)
+    }
+
+    // MARK: - hasBookmark
+
+    @Test("hasBookmark returns false when no bookmark stored")
+    func hasBookmarkFalseWhenEmpty() {
+        BookmarkManager.shared.clearBookmark()
+
+        #expect(BookmarkManager.shared.hasBookmark == false)
+    }
+
+    @Test("hasBookmark returns true after storing bookmark")
+    func hasBookmarkTrueAfterStore() throws {
+        // Use temp directory which should be accessible
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        #expect(BookmarkManager.shared.hasBookmark == true)
+    }
+
+    // MARK: - clearBookmark
+
+    @Test("clearBookmark removes stored bookmark")
+    func clearBookmarkRemovesBookmark() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        BookmarkManager.shared.clearBookmark()
+
+        #expect(BookmarkManager.shared.hasBookmark == false)
+    }
+
+    @Test("clearBookmark is safe to call when no bookmark exists")
+    func clearBookmarkSafeWhenEmpty() {
+        BookmarkManager.shared.clearBookmark()
+        BookmarkManager.shared.clearBookmark()
+
+        #expect(BookmarkManager.shared.hasBookmark == false)
+    }
+
+    // MARK: - resolveBookmark
+
+    @Test("resolveBookmark returns nil when no bookmark stored")
+    func resolveBookmarkNilWhenEmpty() {
+        BookmarkManager.shared.clearBookmark()
+
+        let resolved = BookmarkManager.shared.resolveBookmark()
+
+        #expect(resolved == nil)
+    }
+
+    @Test("resolveBookmark returns URL after storing bookmark")
+    func resolveBookmarkReturnsURLAfterStore() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        let resolved = BookmarkManager.shared.resolveBookmark()
+
+        #expect(resolved != nil)
+        // Use standardizedFileURL to resolve symlinks for path comparison
+        #expect(resolved?.standardizedFileURL.path == tempURL.standardizedFileURL.path)
+    }
+
+    // MARK: - bookmarkedLocationName
+
+    @Test("bookmarkedLocationName returns nil when no bookmark stored")
+    func bookmarkedLocationNameNilWhenEmpty() {
+        BookmarkManager.shared.clearBookmark()
+
+        #expect(BookmarkManager.shared.bookmarkedLocationName == nil)
+    }
+
+    @Test("bookmarkedLocationName returns last path component")
+    func bookmarkedLocationNameReturnsLastComponent() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        let name = BookmarkManager.shared.bookmarkedLocationName
+
+        // Temporary directory usually named something like "tmp" or has a UUID
+        #expect(name != nil)
+        #expect(name == tempURL.lastPathComponent)
+    }
+
+    // MARK: - storeBookmark
+
+    @Test("storeBookmark persists across accesses")
+    func storeBookmarkPersists() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        // Access through singleton multiple times
+        #expect(BookmarkManager.shared.hasBookmark)
+        #expect(BookmarkManager.shared.resolveBookmark() != nil)
+        #expect(BookmarkManager.shared.hasBookmark)
+    }
+
+    @Test("storeBookmark replaces existing bookmark")
+    func storeBookmarkReplaces() throws {
+        let tempURL1 = FileManager.default.temporaryDirectory
+        let tempURL2 = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+
+        try BookmarkManager.shared.storeBookmark(for: tempURL1)
+        try BookmarkManager.shared.storeBookmark(for: tempURL2)
+
+        let resolved = BookmarkManager.shared.resolveBookmark()
+        #expect(resolved?.path == tempURL2.path)
+    }
+
+    // MARK: - Thread Safety (Sendable)
+
+    @Test("BookmarkManager.shared is accessible from MainActor")
+    func accessibleFromMainActor() {
+        // This test runs on MainActor
+        let manager = BookmarkManager.shared
+        _ = manager.hasBookmark
+    }
+
+    // MARK: - UserDefaults Integration
+
+    @Test("bookmark is stored in UserDefaults")
+    func storedInUserDefaults() throws {
+        BookmarkManager.shared.clearBookmark()
+
+        // Verify cleared
+        let beforeStore = UserDefaults.standard.data(forKey: "saveLocationBookmark")
+        #expect(beforeStore == nil)
+
+        // Store bookmark
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        // Verify stored
+        let afterStore = UserDefaults.standard.data(forKey: "saveLocationBookmark")
+        #expect(afterStore != nil)
+    }
+
+    @Test("clearBookmark removes from UserDefaults")
+    func clearRemovesFromUserDefaults() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        BookmarkManager.shared.clearBookmark()
+
+        let data = UserDefaults.standard.data(forKey: "saveLocationBookmark")
+        #expect(data == nil)
+    }
+
+    // MARK: - Edge Cases
+
+    @Test("resolveBookmark handles invalid bookmark data")
+    func resolveHandlesInvalidData() {
+        // Manually set invalid data
+        UserDefaults.standard.set(Data([0x00, 0x01, 0x02]), forKey: "saveLocationBookmark")
+
+        let resolved = BookmarkManager.shared.resolveBookmark()
+
+        // Should return nil for invalid data and clear the bookmark
+        #expect(resolved == nil)
+        #expect(BookmarkManager.shared.hasBookmark == false)
+    }
+}
+
+// MARK: - BookmarkManager Integration Tests
+
+@Suite("BookmarkManager Integration Tests")
+@MainActor
+struct BookmarkManagerIntegrationTests {
+    init() {
+        BookmarkManager.shared.clearBookmark()
+    }
+
+    @Test("full bookmark lifecycle: store, resolve, clear")
+    func fullLifecycle() throws {
+        // Initial state
+        #expect(BookmarkManager.shared.hasBookmark == false)
+        #expect(BookmarkManager.shared.resolveBookmark() == nil)
+        #expect(BookmarkManager.shared.bookmarkedLocationName == nil)
+
+        // Store
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        // After store
+        #expect(BookmarkManager.shared.hasBookmark == true)
+        #expect(BookmarkManager.shared.resolveBookmark() != nil)
+        #expect(BookmarkManager.shared.bookmarkedLocationName != nil)
+
+        // Clear
+        BookmarkManager.shared.clearBookmark()
+
+        // After clear
+        #expect(BookmarkManager.shared.hasBookmark == false)
+        #expect(BookmarkManager.shared.resolveBookmark() == nil)
+        #expect(BookmarkManager.shared.bookmarkedLocationName == nil)
+    }
+
+    @Test("AppViewModel uses BookmarkManager correctly")
+    func appViewModelIntegration() throws {
+        BookmarkManager.shared.clearBookmark()
+
+        let viewModel = AppViewModel()
+
+        // Default state
+        #expect(viewModel.hasCustomSaveLocation == false)
+        #expect(viewModel.saveLocationName == "Desktop")
+
+        // Store bookmark
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        // After bookmark stored
+        #expect(viewModel.hasCustomSaveLocation == true)
+        #expect(viewModel.saveLocationName == tempURL.lastPathComponent)
+        // Use standardizedFileURL to resolve symlinks for path comparison
+        #expect(viewModel.saveLocation.standardizedFileURL.path == tempURL.standardizedFileURL.path)
+
+        // Clear for cleanup
+        BookmarkManager.shared.clearBookmark()
+    }
+}

--- a/BifcodePackage/Tests/BifcodeFeatureTests/CodePanelTests.swift
+++ b/BifcodePackage/Tests/BifcodeFeatureTests/CodePanelTests.swift
@@ -1,0 +1,317 @@
+//
+//  CodePanelTests.swift
+//
+//  Created on 18.12.2025.
+//  Copyright © 2025 IGR Soft. All rights reserved.
+//
+
+import CodeEditLanguages
+import Foundation
+import Testing
+@testable import BifcodeFeature
+
+// MARK: - PanelType Tests
+
+@Suite("PanelType Tests")
+struct PanelTypeTests {
+    // MARK: - Raw Values
+
+    @Test("rawValue returns 'do' for doPanel")
+    func rawValueDoPanel() {
+        #expect(PanelType.doPanel.rawValue == "do")
+    }
+
+    @Test("rawValue returns 'dont' for dontPanel")
+    func rawValueDontPanel() {
+        #expect(PanelType.dontPanel.rawValue == "dont")
+    }
+
+    // MARK: - Initialization from Raw Value
+
+    @Test("init from 'do' returns doPanel")
+    func initFromRawValueDo() {
+        let type = PanelType(rawValue: "do")
+        #expect(type == .doPanel)
+    }
+
+    @Test("init from 'dont' returns dontPanel")
+    func initFromRawValueDont() {
+        let type = PanelType(rawValue: "dont")
+        #expect(type == .dontPanel)
+    }
+
+    @Test("init from invalid rawValue returns nil")
+    func initFromInvalidRawValue() {
+        let type = PanelType(rawValue: "maybe")
+        #expect(type == nil)
+    }
+
+    // MARK: - Sendable Conformance
+
+    @Test("PanelType is Sendable")
+    func sendableConformance() async {
+        let type = PanelType.doPanel
+        await Task.detached {
+            // If this compiles, it proves Sendable conformance
+            _ = type.rawValue
+        }.value
+    }
+
+    // MARK: - Equality
+
+    @Test("doPanel equals doPanel")
+    func doPanelEquality() {
+        #expect(PanelType.doPanel == PanelType.doPanel)
+    }
+
+    @Test("dontPanel equals dontPanel")
+    func dontPanelEquality() {
+        #expect(PanelType.dontPanel == PanelType.dontPanel)
+    }
+
+    @Test("doPanel does not equal dontPanel")
+    func doPanelNotEqualDontPanel() {
+        #expect(PanelType.doPanel != PanelType.dontPanel)
+    }
+}
+
+// MARK: - CodePanel Tests
+
+@Suite("CodePanel Tests")
+@MainActor
+struct CodePanelTests {
+    // MARK: - Initialization
+
+    @Test("init creates panel with specified type")
+    func initWithType() {
+        let doPanel = CodePanel(type: .doPanel)
+        let dontPanel = CodePanel(type: .dontPanel)
+
+        #expect(doPanel.type == .doPanel)
+        #expect(dontPanel.type == .dontPanel)
+    }
+
+    @Test("init creates panel with default empty title")
+    func initWithDefaultTitle() {
+        let panel = CodePanel(type: .doPanel)
+
+        #expect(panel.title == "")
+    }
+
+    @Test("init creates panel with specified title")
+    func initWithTitle() {
+        let panel = CodePanel(type: .doPanel, title: "Best Practices")
+
+        #expect(panel.title == "Best Practices")
+    }
+
+    @Test("init creates panel with default Swift language")
+    func initWithDefaultLanguage() {
+        let panel = CodePanel(type: .doPanel)
+
+        #expect(panel.language == .swift)
+    }
+
+    @Test("init creates panel with specified language")
+    func initWithLanguage() {
+        let panel = CodePanel(type: .doPanel, language: .python)
+
+        #expect(panel.language == .python)
+    }
+
+    @Test("init creates panel with all parameters")
+    func initWithAllParameters() {
+        let panel = CodePanel(type: .dontPanel, title: "Anti-Patterns", language: .javascript)
+
+        #expect(panel.type == .dontPanel)
+        #expect(panel.title == "Anti-Patterns")
+        #expect(panel.language == .javascript)
+    }
+
+    @Test("init creates panel with empty code")
+    func initWithEmptyCode() {
+        let panel = CodePanel(type: .doPanel)
+
+        #expect(panel.code == "")
+    }
+
+    @Test("init creates panel with unique id")
+    func initWithUniqueId() {
+        let panel1 = CodePanel(type: .doPanel)
+        let panel2 = CodePanel(type: .doPanel)
+
+        #expect(panel1.id != panel2.id)
+    }
+
+    @Test("init creates panel with initialized editorState")
+    func initWithEditorState() {
+        let panel = CodePanel(type: .doPanel)
+
+        // EditorState should be initialized (not nil)
+        _ = panel.editorState
+    }
+
+    // MARK: - Property Updates
+
+    @Test("code property can be updated")
+    func codeUpdate() {
+        let panel = CodePanel(type: .doPanel)
+        panel.code = "let x = 1"
+
+        #expect(panel.code == "let x = 1")
+    }
+
+    @Test("title property can be updated")
+    func titleUpdate() {
+        let panel = CodePanel(type: .doPanel)
+        panel.title = "New Title"
+
+        #expect(panel.title == "New Title")
+    }
+
+    @Test("language property can be updated")
+    func languageUpdate() {
+        let panel = CodePanel(type: .doPanel)
+        panel.language = .rust
+
+        #expect(panel.language == .rust)
+    }
+
+    @Test("code can contain multiline text")
+    func multilineCode() {
+        let panel = CodePanel(type: .doPanel)
+        let multilineCode = """
+        func hello() {
+            print("Hello, World!")
+        }
+        """
+        panel.code = multilineCode
+
+        #expect(panel.code.contains("func hello()"))
+        #expect(panel.code.contains("print"))
+    }
+
+    @Test("code can contain special characters")
+    func codeWithSpecialCharacters() {
+        let panel = CodePanel(type: .doPanel)
+        panel.code = "let emoji = \"🎉\"; // comment"
+
+        #expect(panel.code.contains("🎉"))
+        #expect(panel.code.contains("//"))
+    }
+
+    @Test("title can contain special characters")
+    func titleWithSpecialCharacters() {
+        let panel = CodePanel(type: .doPanel)
+        panel.title = "Examples: Swift & Kotlin™"
+
+        #expect(panel.title.contains("&"))
+        #expect(panel.title.contains("™"))
+    }
+
+    // MARK: - Type Immutability
+
+    @Test("type property is immutable after init")
+    func typeImmutable() {
+        let panel = CodePanel(type: .doPanel)
+
+        // type is let, so this should not compile:
+        // panel.type = .dontPanel
+
+        #expect(panel.type == .doPanel)
+    }
+
+    @Test("id property is immutable after init")
+    func idImmutable() {
+        let panel = CodePanel(type: .doPanel)
+        let originalId = panel.id
+
+        // id is let, so this should not compile:
+        // panel.id = UUID()
+
+        #expect(panel.id == originalId)
+    }
+
+    // MARK: - Identifiable Conformance
+
+    @Test("CodePanel conforms to Identifiable")
+    func identifiableConformance() {
+        let panel = CodePanel(type: .doPanel)
+
+        // Access id property to verify Identifiable conformance
+        let _: UUID = panel.id
+    }
+
+    // MARK: - Language Support
+
+    @Test("panel supports common programming languages")
+    func languageSupportCommon() {
+        let languages: [CodeLanguage] = [
+            .swift, .python, .javascript, .typescript,
+            .java, .kotlin, .rust, .go, .c, .cpp
+        ]
+
+        for language in languages {
+            let panel = CodePanel(type: .doPanel, language: language)
+            #expect(panel.language == language)
+        }
+    }
+
+    // MARK: - Edge Cases
+
+    @Test("code can be set to very long string")
+    func veryLongCode() {
+        let panel = CodePanel(type: .doPanel)
+        let longCode = String(repeating: "let x = 1\n", count: 100)
+        panel.code = longCode
+
+        #expect(panel.code.count >= 1000)  // 100 * 10 = 1000 chars
+    }
+
+    @Test("title can be set to very long string")
+    func veryLongTitle() {
+        let panel = CodePanel(type: .doPanel)
+        let longTitle = String(repeating: "A", count: 200)
+        panel.title = longTitle
+
+        #expect(panel.title.count == 200)
+    }
+
+    @Test("code can be cleared")
+    func clearCode() {
+        let panel = CodePanel(type: .doPanel)
+        panel.code = "let x = 1"
+        panel.code = ""
+
+        #expect(panel.code.isEmpty)
+    }
+
+    @Test("title can be cleared")
+    func clearTitle() {
+        let panel = CodePanel(type: .doPanel)
+        panel.title = "Title"
+        panel.title = ""
+
+        #expect(panel.title.isEmpty)
+    }
+
+    // MARK: - Multiple Panels
+
+    @Test("multiple panels maintain independent state")
+    func independentPanels() {
+        let panel1 = CodePanel(type: .doPanel, title: "Panel 1")
+        let panel2 = CodePanel(type: .dontPanel, title: "Panel 2")
+
+        panel1.code = "Code 1"
+        panel2.code = "Code 2"
+        panel1.language = .python
+        panel2.language = .rust
+
+        #expect(panel1.code == "Code 1")
+        #expect(panel2.code == "Code 2")
+        #expect(panel1.language == .python)
+        #expect(panel2.language == .rust)
+        #expect(panel1.title == "Panel 1")
+        #expect(panel2.title == "Panel 2")
+    }
+}

--- a/BifcodePackage/Tests/BifcodeFeatureTests/ExportIntegrationTests.swift
+++ b/BifcodePackage/Tests/BifcodeFeatureTests/ExportIntegrationTests.swift
@@ -1,0 +1,324 @@
+//
+//  ExportIntegrationTests.swift
+//
+//  Created on 18.12.2025.
+//  Copyright © 2025 IGR Soft. All rights reserved.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import BifcodeFeature
+
+// MARK: - Export Integration Tests
+
+@Suite("Export Integration Tests")
+@MainActor
+struct ExportIntegrationTests {
+    // MARK: - Setup
+
+    init() {
+        BookmarkManager.shared.clearBookmark()
+    }
+
+    // MARK: - Save Image Tests
+
+    @Test("saveImage throws conversionFailed for invalid image")
+    func saveImageThrowsForInvalidImage() async throws {
+        let viewModel = AppViewModel()
+
+        // Create an empty/invalid NSImage
+        let invalidImage = NSImage()
+
+        do {
+            try await viewModel.saveImage(invalidImage)
+            Issue.record("Expected conversionFailed error")
+        } catch let error as ExportError {
+            #expect(error == .conversionFailed)
+        }
+    }
+
+    @Test("saveImage succeeds with valid image")
+    func saveImageSucceedsWithValidImage() async throws {
+        let viewModel = AppViewModel()
+
+        // Create a valid test image
+        let image = createTestImage(width: 100, height: 100)
+
+        // Use temp directory as save location
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        // Should not throw
+        try await viewModel.saveImage(image)
+
+        // Cleanup - remove the saved file
+        let files = try FileManager.default.contentsOfDirectory(
+            at: tempURL,
+            includingPropertiesForKeys: nil
+        )
+        for file in files where file.lastPathComponent.hasPrefix("bifcode-") {
+            try? FileManager.default.removeItem(at: file)
+        }
+
+        BookmarkManager.shared.clearBookmark()
+    }
+
+    @Test("saveImage creates file with correct naming pattern")
+    func saveImageCreatesFileWithCorrectName() async throws {
+        let viewModel = AppViewModel()
+
+        // Create a valid test image
+        let image = createTestImage(width: 100, height: 100)
+
+        // Use temp directory
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        // Get files before
+        let filesBefore = try FileManager.default.contentsOfDirectory(
+            at: tempURL,
+            includingPropertiesForKeys: nil
+        )
+        let bifcodeFilesBefore = filesBefore.filter { $0.lastPathComponent.hasPrefix("bifcode-") }
+
+        // Save image
+        try await viewModel.saveImage(image)
+
+        // Get files after
+        let filesAfter = try FileManager.default.contentsOfDirectory(
+            at: tempURL,
+            includingPropertiesForKeys: nil
+        )
+        let bifcodeFilesAfter = filesAfter.filter { $0.lastPathComponent.hasPrefix("bifcode-") }
+
+        // Should have one more file
+        #expect(bifcodeFilesAfter.count == bifcodeFilesBefore.count + 1)
+
+        // Find the new file
+        let newFiles = Set(bifcodeFilesAfter).subtracting(Set(bifcodeFilesBefore))
+        #expect(newFiles.count == 1)
+
+        if let newFile = newFiles.first {
+            // Verify naming pattern: bifcode-{timestamp}.png
+            #expect(newFile.lastPathComponent.hasPrefix("bifcode-"))
+            #expect(newFile.pathExtension == "png")
+
+            // Cleanup
+            try? FileManager.default.removeItem(at: newFile)
+        }
+
+        BookmarkManager.shared.clearBookmark()
+    }
+
+    @Test("saveImage creates valid PNG file")
+    func saveImageCreatesValidPNG() async throws {
+        let viewModel = AppViewModel()
+
+        // Create a valid test image
+        let image = createTestImage(width: 200, height: 150)
+
+        // Use temp directory
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        // Save image
+        try await viewModel.saveImage(image)
+
+        // Find the saved file
+        let files = try FileManager.default.contentsOfDirectory(
+            at: tempURL,
+            includingPropertiesForKeys: nil
+        )
+        let bifcodeFile = files.first { $0.lastPathComponent.hasPrefix("bifcode-") }
+
+        #expect(bifcodeFile != nil)
+
+        if let file = bifcodeFile {
+            // Read and verify PNG
+            let data = try Data(contentsOf: file)
+            #expect(!data.isEmpty)
+
+            // PNG magic number: 89 50 4E 47 0D 0A 1A 0A
+            let pngMagic: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+            let fileHeader = Array(data.prefix(8))
+            #expect(fileHeader == pngMagic)
+
+            // Cleanup
+            try? FileManager.default.removeItem(at: file)
+        }
+
+        BookmarkManager.shared.clearBookmark()
+    }
+
+    @Test("saveImage uses default Desktop when no bookmark")
+    func saveImageUsesDesktopByDefault() async throws {
+        BookmarkManager.shared.clearBookmark()
+
+        let viewModel = AppViewModel()
+
+        // Verify save location is Desktop
+        let location = viewModel.saveLocation
+        #expect(location.path.contains("Desktop"))
+    }
+
+    // MARK: - Helper Methods
+
+    private func createTestImage(width: Int, height: Int) -> NSImage {
+        let image = NSImage(size: NSSize(width: width, height: height))
+        image.lockFocus()
+
+        // Draw a simple colored rectangle
+        NSColor.blue.setFill()
+        NSBezierPath.fill(NSRect(x: 0, y: 0, width: width, height: height))
+
+        image.unlockFocus()
+        return image
+    }
+}
+
+// MARK: - Save Location Tests
+
+@Suite("Save Location Tests")
+@MainActor
+struct SaveLocationTests {
+    init() {
+        BookmarkManager.shared.clearBookmark()
+    }
+
+    @Test("saveLocation returns Desktop URL by default")
+    func defaultSaveLocation() {
+        let viewModel = AppViewModel()
+
+        let location = viewModel.saveLocation
+
+        #expect(location.isFileURL)
+        #expect(location.path.contains("Desktop"))
+    }
+
+    @Test("saveLocation returns bookmarked URL when set")
+    func bookmarkedSaveLocation() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        let viewModel = AppViewModel()
+
+        // Use standardizedFileURL to resolve symlinks for path comparison
+        #expect(viewModel.saveLocation.standardizedFileURL.path == tempURL.standardizedFileURL.path)
+
+        BookmarkManager.shared.clearBookmark()
+    }
+
+    @Test("hasCustomSaveLocation reflects bookmark state")
+    func hasCustomSaveLocationState() throws {
+        let viewModel = AppViewModel()
+
+        // Initially false
+        #expect(viewModel.hasCustomSaveLocation == false)
+
+        // After setting bookmark
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        #expect(viewModel.hasCustomSaveLocation == true)
+
+        // After clearing
+        BookmarkManager.shared.clearBookmark()
+
+        #expect(viewModel.hasCustomSaveLocation == false)
+    }
+
+    @Test("saveLocationName returns folder name")
+    func saveLocationNameReturnsName() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+        try BookmarkManager.shared.storeBookmark(for: tempURL)
+
+        let viewModel = AppViewModel()
+
+        #expect(viewModel.saveLocationName == tempURL.lastPathComponent)
+
+        BookmarkManager.shared.clearBookmark()
+    }
+
+    @Test("saveLocationName returns 'Desktop' by default")
+    func saveLocationNameDefault() {
+        let viewModel = AppViewModel()
+
+        #expect(viewModel.saveLocationName == "Desktop")
+    }
+}
+
+// MARK: - Panel State Integration Tests
+
+@Suite("Panel State Integration Tests")
+@MainActor
+struct PanelStateIntegrationTests {
+    @Test("panels maintain state through language changes")
+    func panelsStateThroughLanguageChange() {
+        let viewModel = AppViewModel()
+
+        // Set panel state
+        viewModel.doPanel.code = "let x = 1"
+        viewModel.doPanel.title = "Do Title"
+        viewModel.dontPanel.code = "var y = 2"
+        viewModel.dontPanel.title = "Dont Title"
+
+        // Change language
+        viewModel.setLanguage(.python)
+        viewModel.setLanguage(.javascript)
+        viewModel.setLanguage(.swift)
+
+        // Verify state preserved
+        #expect(viewModel.doPanel.code == "let x = 1")
+        #expect(viewModel.doPanel.title == "Do Title")
+        #expect(viewModel.dontPanel.code == "var y = 2")
+        #expect(viewModel.dontPanel.title == "Dont Title")
+    }
+
+    @Test("panels maintain state through title updates")
+    func panelsStateThroughTitleUpdate() {
+        let viewModel = AppViewModel()
+
+        // Set panel state
+        viewModel.doPanel.code = "let x = 1"
+        viewModel.dontPanel.code = "var y = 2"
+        viewModel.setLanguage(.python)
+
+        // Update titles
+        viewModel.update(doTitle: "New Do", dontTitle: "New Dont")
+
+        // Verify code and language preserved
+        #expect(viewModel.doPanel.code == "let x = 1")
+        #expect(viewModel.dontPanel.code == "var y = 2")
+        #expect(viewModel.doPanel.language == .python)
+        #expect(viewModel.dontPanel.language == .python)
+    }
+
+    @Test("complete workflow: create, edit, save")
+    func completeWorkflow() async throws {
+        let viewModel = AppViewModel()
+
+        // 1. Set up panels
+        viewModel.doPanel.code = """
+        // Good practice
+        let userName = user.name
+        """
+        viewModel.doPanel.title = "Best Practice"
+        viewModel.dontPanel.code = """
+        // Avoid this
+        let n = u.n
+        """
+        viewModel.dontPanel.title = "Anti-Pattern"
+        viewModel.setLanguage(.swift)
+
+        // 2. Verify state
+        #expect(viewModel.doPanel.type == .doPanel)
+        #expect(viewModel.dontPanel.type == .dontPanel)
+        #expect(viewModel.doPanel.language == .swift)
+
+        // 3. Titles can be updated
+        viewModel.update(doTitle: "Updated Do", dontTitle: "Updated Dont")
+        #expect(viewModel.doPanel.title == "Updated Do")
+        #expect(viewModel.dontPanel.title == "Updated Dont")
+    }
+}

--- a/BifcodePackage/Tests/BifcodeFeatureTests/SettingsTypesTests.swift
+++ b/BifcodePackage/Tests/BifcodeFeatureTests/SettingsTypesTests.swift
@@ -1,0 +1,559 @@
+//
+//  SettingsTypesTests.swift
+//
+//  Created on 18.12.2025.
+//  Copyright © 2025 IGR Soft. All rights reserved.
+//
+
+import Testing
+@testable import BifcodeFeature
+
+// MARK: - IndicatorPosition Tests
+
+@Suite("IndicatorPosition Tests")
+struct IndicatorPositionTests {
+    // MARK: - Raw Values
+
+    @Test("rawValue returns correct string for topRight")
+    func rawValueTopRight() {
+        #expect(IndicatorPosition.topRight.rawValue == "top-right")
+    }
+
+    @Test("rawValue returns correct string for bottomRight")
+    func rawValueBottomRight() {
+        #expect(IndicatorPosition.bottomRight.rawValue == "bottom-right")
+    }
+
+    // MARK: - Labels
+
+    @Test("label returns 'Top Right' for topRight")
+    func labelTopRight() {
+        #expect(IndicatorPosition.topRight.label == "Top Right")
+    }
+
+    @Test("label returns 'Bottom Right' for bottomRight")
+    func labelBottomRight() {
+        #expect(IndicatorPosition.bottomRight.label == "Bottom Right")
+    }
+
+    // MARK: - CaseIterable
+
+    @Test("allCases contains exactly 2 positions")
+    func allCasesCount() {
+        #expect(IndicatorPosition.allCases.count == 2)
+    }
+
+    @Test("allCases contains topRight and bottomRight")
+    func allCasesContains() {
+        #expect(IndicatorPosition.allCases.contains(.topRight))
+        #expect(IndicatorPosition.allCases.contains(.bottomRight))
+    }
+
+    // MARK: - Initialization from Raw Value
+
+    @Test("init from 'top-right' returns topRight")
+    func initFromRawValueTopRight() {
+        let position = IndicatorPosition(rawValue: "top-right")
+        #expect(position == .topRight)
+    }
+
+    @Test("init from 'bottom-right' returns bottomRight")
+    func initFromRawValueBottomRight() {
+        let position = IndicatorPosition(rawValue: "bottom-right")
+        #expect(position == .bottomRight)
+    }
+
+    @Test("init from invalid rawValue returns nil")
+    func initFromInvalidRawValue() {
+        let position = IndicatorPosition(rawValue: "invalid")
+        #expect(position == nil)
+    }
+
+    // MARK: - Sendable Conformance
+
+    @Test("IndicatorPosition is Sendable")
+    func sendableConformance() async {
+        let position = IndicatorPosition.topRight
+        await Task.detached {
+            // If this compiles, it proves Sendable conformance
+            _ = position.rawValue
+        }.value
+    }
+}
+
+// MARK: - IndicatorStyle Tests
+
+@Suite("IndicatorStyle Tests")
+struct IndicatorStyleTests {
+    // MARK: - Raw Values
+
+    @Test("rawValue returns 'icon' for iconOnly")
+    func rawValueIconOnly() {
+        #expect(IndicatorStyle.iconOnly.rawValue == "icon")
+    }
+
+    @Test("rawValue returns 'text' for textOnly")
+    func rawValueTextOnly() {
+        #expect(IndicatorStyle.textOnly.rawValue == "text")
+    }
+
+    @Test("rawValue returns 'both' for iconAndText")
+    func rawValueIconAndText() {
+        #expect(IndicatorStyle.iconAndText.rawValue == "both")
+    }
+
+    // MARK: - Labels
+
+    @Test("label returns 'Icon Only' for iconOnly")
+    func labelIconOnly() {
+        #expect(IndicatorStyle.iconOnly.label == "Icon Only")
+    }
+
+    @Test("label returns 'Text Only' for textOnly")
+    func labelTextOnly() {
+        #expect(IndicatorStyle.textOnly.label == "Text Only")
+    }
+
+    @Test("label returns 'Icon + Text' for iconAndText")
+    func labelIconAndText() {
+        #expect(IndicatorStyle.iconAndText.label == "Icon + Text")
+    }
+
+    // MARK: - CaseIterable
+
+    @Test("allCases contains exactly 3 styles")
+    func allCasesCount() {
+        #expect(IndicatorStyle.allCases.count == 3)
+    }
+
+    @Test("allCases contains all styles")
+    func allCasesContains() {
+        #expect(IndicatorStyle.allCases.contains(.iconOnly))
+        #expect(IndicatorStyle.allCases.contains(.textOnly))
+        #expect(IndicatorStyle.allCases.contains(.iconAndText))
+    }
+
+    // MARK: - Initialization from Raw Value
+
+    @Test("init from 'icon' returns iconOnly")
+    func initFromRawValueIcon() {
+        let style = IndicatorStyle(rawValue: "icon")
+        #expect(style == .iconOnly)
+    }
+
+    @Test("init from 'text' returns textOnly")
+    func initFromRawValueText() {
+        let style = IndicatorStyle(rawValue: "text")
+        #expect(style == .textOnly)
+    }
+
+    @Test("init from 'both' returns iconAndText")
+    func initFromRawValueBoth() {
+        let style = IndicatorStyle(rawValue: "both")
+        #expect(style == .iconAndText)
+    }
+
+    @Test("init from invalid rawValue returns nil")
+    func initFromInvalidRawValue() {
+        let style = IndicatorStyle(rawValue: "invalid")
+        #expect(style == nil)
+    }
+}
+
+// MARK: - IndicatorIcon Tests
+
+@Suite("IndicatorIcon Tests")
+struct IndicatorIconTests {
+    // MARK: - Positive Icons System Names
+
+    @Test("checkmark systemName is 'checkmark'")
+    func checkmarkSystemName() {
+        #expect(IndicatorIcon.checkmark.systemName == "checkmark")
+    }
+
+    @Test("checkmarkCircle systemName is 'checkmark.circle'")
+    func checkmarkCircleSystemName() {
+        #expect(IndicatorIcon.checkmarkCircle.systemName == "checkmark.circle")
+    }
+
+    @Test("checkmarkSquare systemName is 'checkmark.square'")
+    func checkmarkSquareSystemName() {
+        #expect(IndicatorIcon.checkmarkSquare.systemName == "checkmark.square")
+    }
+
+    @Test("thumbsUp systemName is 'hand.thumbsup'")
+    func thumbsUpSystemName() {
+        #expect(IndicatorIcon.thumbsUp.systemName == "hand.thumbsup")
+    }
+
+    @Test("star systemName is 'star.fill'")
+    func starSystemName() {
+        #expect(IndicatorIcon.star.systemName == "star.fill")
+    }
+
+    // MARK: - Negative Icons System Names
+
+    @Test("xmark systemName is 'xmark'")
+    func xmarkSystemName() {
+        #expect(IndicatorIcon.xmark.systemName == "xmark")
+    }
+
+    @Test("xmarkCircle systemName is 'xmark.circle'")
+    func xmarkCircleSystemName() {
+        #expect(IndicatorIcon.xmarkCircle.systemName == "xmark.circle")
+    }
+
+    @Test("xmarkSquare systemName is 'xmark.square'")
+    func xmarkSquareSystemName() {
+        #expect(IndicatorIcon.xmarkSquare.systemName == "xmark.square")
+    }
+
+    @Test("thumbsDown systemName is 'hand.thumbsdown'")
+    func thumbsDownSystemName() {
+        #expect(IndicatorIcon.thumbsDown.systemName == "hand.thumbsdown")
+    }
+
+    @Test("warning systemName is 'exclamationmark.triangle'")
+    func warningSystemName() {
+        #expect(IndicatorIcon.warning.systemName == "exclamationmark.triangle")
+    }
+
+    // MARK: - Positive Icons Collection
+
+    @Test("positiveIcons contains exactly 5 icons")
+    func positiveIconsCount() {
+        #expect(IndicatorIcon.positiveIcons.count == 5)
+    }
+
+    @Test("positiveIcons contains checkmark")
+    func positiveIconsContainsCheckmark() {
+        #expect(IndicatorIcon.positiveIcons.contains(.checkmark))
+    }
+
+    @Test("positiveIcons contains checkmarkCircle")
+    func positiveIconsContainsCheckmarkCircle() {
+        #expect(IndicatorIcon.positiveIcons.contains(.checkmarkCircle))
+    }
+
+    @Test("positiveIcons contains checkmarkSquare")
+    func positiveIconsContainsCheckmarkSquare() {
+        #expect(IndicatorIcon.positiveIcons.contains(.checkmarkSquare))
+    }
+
+    @Test("positiveIcons contains thumbsUp")
+    func positiveIconsContainsThumbsUp() {
+        #expect(IndicatorIcon.positiveIcons.contains(.thumbsUp))
+    }
+
+    @Test("positiveIcons contains star")
+    func positiveIconsContainsStar() {
+        #expect(IndicatorIcon.positiveIcons.contains(.star))
+    }
+
+    @Test("positiveIcons does not contain negative icons")
+    func positiveIconsDoesNotContainNegative() {
+        #expect(!IndicatorIcon.positiveIcons.contains(.xmark))
+        #expect(!IndicatorIcon.positiveIcons.contains(.xmarkCircle))
+        #expect(!IndicatorIcon.positiveIcons.contains(.xmarkSquare))
+        #expect(!IndicatorIcon.positiveIcons.contains(.thumbsDown))
+        #expect(!IndicatorIcon.positiveIcons.contains(.warning))
+    }
+
+    // MARK: - Negative Icons Collection
+
+    @Test("negativeIcons contains exactly 5 icons")
+    func negativeIconsCount() {
+        #expect(IndicatorIcon.negativeIcons.count == 5)
+    }
+
+    @Test("negativeIcons contains xmark")
+    func negativeIconsContainsXmark() {
+        #expect(IndicatorIcon.negativeIcons.contains(.xmark))
+    }
+
+    @Test("negativeIcons contains xmarkCircle")
+    func negativeIconsContainsXmarkCircle() {
+        #expect(IndicatorIcon.negativeIcons.contains(.xmarkCircle))
+    }
+
+    @Test("negativeIcons contains xmarkSquare")
+    func negativeIconsContainsXmarkSquare() {
+        #expect(IndicatorIcon.negativeIcons.contains(.xmarkSquare))
+    }
+
+    @Test("negativeIcons contains thumbsDown")
+    func negativeIconsContainsThumbsDown() {
+        #expect(IndicatorIcon.negativeIcons.contains(.thumbsDown))
+    }
+
+    @Test("negativeIcons contains warning")
+    func negativeIconsContainsWarning() {
+        #expect(IndicatorIcon.negativeIcons.contains(.warning))
+    }
+
+    @Test("negativeIcons does not contain positive icons")
+    func negativeIconsDoesNotContainPositive() {
+        #expect(!IndicatorIcon.negativeIcons.contains(.checkmark))
+        #expect(!IndicatorIcon.negativeIcons.contains(.checkmarkCircle))
+        #expect(!IndicatorIcon.negativeIcons.contains(.checkmarkSquare))
+        #expect(!IndicatorIcon.negativeIcons.contains(.thumbsUp))
+        #expect(!IndicatorIcon.negativeIcons.contains(.star))
+    }
+
+    // MARK: - CaseIterable
+
+    @Test("allCases contains exactly 10 icons")
+    func allCasesCount() {
+        #expect(IndicatorIcon.allCases.count == 10)
+    }
+
+    @Test("allCases union equals positive plus negative icons")
+    func allCasesUnion() {
+        let allSet = Set(IndicatorIcon.allCases)
+        let positiveSet = Set(IndicatorIcon.positiveIcons)
+        let negativeSet = Set(IndicatorIcon.negativeIcons)
+        #expect(allSet == positiveSet.union(negativeSet))
+    }
+
+    // MARK: - Initialization from Raw Value
+
+    @Test("init from 'checkmark' returns checkmark")
+    func initFromRawValueCheckmark() {
+        let icon = IndicatorIcon(rawValue: "checkmark")
+        #expect(icon == .checkmark)
+    }
+
+    @Test("init from 'checkmark.circle' returns checkmarkCircle")
+    func initFromRawValueCheckmarkCircle() {
+        let icon = IndicatorIcon(rawValue: "checkmark.circle")
+        #expect(icon == .checkmarkCircle)
+    }
+
+    @Test("init from 'hand.thumbsup' returns thumbsUp")
+    func initFromRawValueThumbsUp() {
+        let icon = IndicatorIcon(rawValue: "hand.thumbsup")
+        #expect(icon == .thumbsUp)
+    }
+
+    @Test("init from invalid rawValue returns nil")
+    func initFromInvalidRawValue() {
+        let icon = IndicatorIcon(rawValue: "invalid.icon")
+        #expect(icon == nil)
+    }
+
+    // MARK: - systemName equals rawValue
+
+    @Test("systemName equals rawValue for all icons")
+    func systemNameEqualsRawValue() {
+        for icon in IndicatorIcon.allCases {
+            #expect(icon.systemName == icon.rawValue)
+        }
+    }
+}
+
+// MARK: - WindowLayout Tests
+
+@Suite("WindowLayout Tests")
+struct WindowLayoutTests {
+    // MARK: - Raw Values
+
+    @Test("rawValue returns 'horizontal' for horizontal")
+    func rawValueHorizontal() {
+        #expect(WindowLayout.horizontal.rawValue == "horizontal")
+    }
+
+    @Test("rawValue returns 'vertical' for vertical")
+    func rawValueVertical() {
+        #expect(WindowLayout.vertical.rawValue == "vertical")
+    }
+
+    // MARK: - Labels
+
+    @Test("label returns 'Side by Side' for horizontal")
+    func labelHorizontal() {
+        #expect(WindowLayout.horizontal.label == "Side by Side")
+    }
+
+    @Test("label returns 'Stacked' for vertical")
+    func labelVertical() {
+        #expect(WindowLayout.vertical.label == "Stacked")
+    }
+
+    // MARK: - CaseIterable
+
+    @Test("allCases contains exactly 2 layouts")
+    func allCasesCount() {
+        #expect(WindowLayout.allCases.count == 2)
+    }
+
+    @Test("allCases contains horizontal and vertical")
+    func allCasesContains() {
+        #expect(WindowLayout.allCases.contains(.horizontal))
+        #expect(WindowLayout.allCases.contains(.vertical))
+    }
+
+    // MARK: - Initialization from Raw Value
+
+    @Test("init from 'horizontal' returns horizontal")
+    func initFromRawValueHorizontal() {
+        let layout = WindowLayout(rawValue: "horizontal")
+        #expect(layout == .horizontal)
+    }
+
+    @Test("init from 'vertical' returns vertical")
+    func initFromRawValueVertical() {
+        let layout = WindowLayout(rawValue: "vertical")
+        #expect(layout == .vertical)
+    }
+
+    @Test("init from invalid rawValue returns nil")
+    func initFromInvalidRawValue() {
+        let layout = WindowLayout(rawValue: "diagonal")
+        #expect(layout == nil)
+    }
+}
+
+// MARK: - EditorThemeOption Tests
+
+@Suite("EditorThemeOption Tests")
+struct EditorThemeOptionTests {
+    // MARK: - Raw Values
+
+    @Test("rawValue returns 'atom-one-dark' for atomOneDark")
+    func rawValueAtomOneDark() {
+        #expect(EditorThemeOption.atomOneDark.rawValue == "atom-one-dark")
+    }
+
+    @Test("rawValue returns 'dracula' for dracula")
+    func rawValueDracula() {
+        #expect(EditorThemeOption.dracula.rawValue == "dracula")
+    }
+
+    @Test("rawValue returns 'github-dark' for githubDark")
+    func rawValueGithubDark() {
+        #expect(EditorThemeOption.githubDark.rawValue == "github-dark")
+    }
+
+    @Test("rawValue returns 'monokai' for monokai")
+    func rawValueMonokai() {
+        #expect(EditorThemeOption.monokai.rawValue == "monokai")
+    }
+
+    @Test("rawValue returns 'nord' for nord")
+    func rawValueNord() {
+        #expect(EditorThemeOption.nord.rawValue == "nord")
+    }
+
+    @Test("rawValue returns 'solarized-dark' for solarizedDark")
+    func rawValueSolarizedDark() {
+        #expect(EditorThemeOption.solarizedDark.rawValue == "solarized-dark")
+    }
+
+    @Test("rawValue returns 'xcode-default' for xcodeDefault")
+    func rawValueXcodeDefault() {
+        #expect(EditorThemeOption.xcodeDefault.rawValue == "xcode-default")
+    }
+
+    // MARK: - Labels
+
+    @Test("label returns 'Atom One Dark' for atomOneDark")
+    func labelAtomOneDark() {
+        #expect(EditorThemeOption.atomOneDark.label == "Atom One Dark")
+    }
+
+    @Test("label returns 'Dracula' for dracula")
+    func labelDracula() {
+        #expect(EditorThemeOption.dracula.label == "Dracula")
+    }
+
+    @Test("label returns 'GitHub Dark' for githubDark")
+    func labelGithubDark() {
+        #expect(EditorThemeOption.githubDark.label == "GitHub Dark")
+    }
+
+    @Test("label returns 'Monokai' for monokai")
+    func labelMonokai() {
+        #expect(EditorThemeOption.monokai.label == "Monokai")
+    }
+
+    @Test("label returns 'Nord' for nord")
+    func labelNord() {
+        #expect(EditorThemeOption.nord.label == "Nord")
+    }
+
+    @Test("label returns 'Solarized Dark' for solarizedDark")
+    func labelSolarizedDark() {
+        #expect(EditorThemeOption.solarizedDark.label == "Solarized Dark")
+    }
+
+    @Test("label returns 'Xcode Default' for xcodeDefault")
+    func labelXcodeDefault() {
+        #expect(EditorThemeOption.xcodeDefault.label == "Xcode Default")
+    }
+
+    // MARK: - CaseIterable
+
+    @Test("allCases contains exactly 7 themes")
+    func allCasesCount() {
+        #expect(EditorThemeOption.allCases.count == 7)
+    }
+
+    @Test("allCases contains all themes")
+    func allCasesContains() {
+        #expect(EditorThemeOption.allCases.contains(.atomOneDark))
+        #expect(EditorThemeOption.allCases.contains(.dracula))
+        #expect(EditorThemeOption.allCases.contains(.githubDark))
+        #expect(EditorThemeOption.allCases.contains(.monokai))
+        #expect(EditorThemeOption.allCases.contains(.nord))
+        #expect(EditorThemeOption.allCases.contains(.solarizedDark))
+        #expect(EditorThemeOption.allCases.contains(.xcodeDefault))
+    }
+
+    // MARK: - Initialization from Raw Value
+
+    @Test("init from 'atom-one-dark' returns atomOneDark")
+    func initFromRawValueAtomOneDark() {
+        let theme = EditorThemeOption(rawValue: "atom-one-dark")
+        #expect(theme == .atomOneDark)
+    }
+
+    @Test("init from 'dracula' returns dracula")
+    func initFromRawValueDracula() {
+        let theme = EditorThemeOption(rawValue: "dracula")
+        #expect(theme == .dracula)
+    }
+
+    @Test("init from invalid rawValue returns nil")
+    func initFromInvalidRawValue() {
+        let theme = EditorThemeOption(rawValue: "unknown-theme")
+        #expect(theme == nil)
+    }
+
+    // MARK: - EditorTheme Property
+
+    @Test("editorTheme returns non-nil for all options")
+    func editorThemeNonNil() {
+        for option in EditorThemeOption.allCases {
+            let theme = option.editorTheme
+            // Just verify we can access the theme without crashing
+            _ = theme.background
+        }
+    }
+
+    @Test("atomOneDark editorTheme has correct background color")
+    func atomOneDarkThemeBackground() {
+        let theme = EditorThemeOption.atomOneDark.editorTheme
+        // Atom One Dark background: #282c34 (RGB: 0.16, 0.18, 0.20)
+        let background = theme.background
+        #expect(background != nil)
+    }
+
+    @Test("each theme option maps to unique EditorTheme")
+    func uniqueThemeMappings() {
+        // Verify themes are distinct by checking backgrounds
+        let backgrounds = EditorThemeOption.allCases.map(\.editorTheme.background)
+        let uniqueBackgrounds = Set(backgrounds.map(\.description))
+        // All 7 themes should have unique backgrounds
+        #expect(uniqueBackgrounds.count == 7)
+    }
+}


### PR DESCRIPTION
Add complete unit, integration, and edge case tests covering SettingsTypes enums, CodePanel models, AppViewModel state management, BookmarkManager singleton, and export functionality. All 208 tests passing across 17 test suites. Covers happy path, error scenarios, edge cases (unicode, empty strings, large content), and performance characteristics. Tests use modern Swift Testing framework with @Suite and @Test macros. No functional changes, test coverage only.