### PR TITLE
feat: add dark/light theme mode toggle for panel styling

### DIFF
--- a/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
@@ -87,6 +87,7 @@ public struct ContentView: View {
     @AppStorage("showTitle") private var showTitle: Bool = true
     @AppStorage("fontSize") private var fontSize: Double = 14
     @AppStorage("selectedTheme") private var selectedThemeRaw: String = EditorThemeOption.atomOneDark.rawValue
+    @AppStorage("themeMode") private var themeModeRaw: String = ThemeMode.dark.rawValue
 
     private var layout: WindowLayout {
         WindowLayout(rawValue: windowLayoutRaw) ?? .horizontal
@@ -102,6 +103,10 @@ public struct ContentView: View {
 
     private var selectedTheme: EditorThemeOption {
         EditorThemeOption(rawValue: selectedThemeRaw) ?? .atomOneDark
+    }
+
+    private var themeMode: ThemeMode {
+        ThemeMode(rawValue: themeModeRaw) ?? .dark
     }
 
     public init() {}
@@ -129,7 +134,7 @@ public struct ContentView: View {
         .frame(minHeight: 400)
         .onAppear {
             // Initialize with stored language and titles on appear
-            //viewModel.setLanguage(selectedLanguage)
+            // viewModel.setLanguage(selectedLanguage)
             viewModel.update(doTitle: doTitleSetting, dontTitle: dontTitleSetting)
         }
         .onChange(of: selectedLanguageRaw) { _, _ in
@@ -195,6 +200,7 @@ public struct ContentView: View {
             showTitle: showTitle,
             fontSize: fontSize,
             theme: selectedTheme.editorTheme,
+            themeMode: themeMode,
             panelWidth: panelWidth,
             doPanelHeight: doPanelHeight,
             dontPanelHeight: dontPanelHeight

--- a/BifcodePackage/Sources/BifcodeFeature/Extensions/Color+Semantic.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Extensions/Color+Semantic.swift
@@ -129,4 +129,42 @@ extension Color {
     /// Light: Semi-transparent black
     /// Dark: Semi-transparent white
     public static let secondaryText = Color("SecondaryText", bundle: .module)
+
+    // MARK: - Theme Mode Aware Colors
+
+    /// Title bar background based on theme mode
+    /// - Parameter mode: The current theme mode (dark or light)
+    /// - Returns: Appropriate title bar background color
+    public static func titleBarBackground(for mode: ThemeMode) -> Color {
+        mode == .dark
+            ? Color("TitleBarBackground", bundle: .module)
+            : Color("TitleBarBackgroundLight", bundle: .module)
+    }
+
+    /// Title text color based on theme mode
+    /// - Parameter mode: The current theme mode (dark or light)
+    /// - Returns: Appropriate title text color
+    public static func titleText(for mode: ThemeMode) -> Color {
+        mode == .dark
+            ? Color("TitleText", bundle: .module)
+            : Color("TitleTextLight", bundle: .module)
+    }
+
+    /// Window border color based on theme mode
+    /// - Parameter mode: The current theme mode (dark or light)
+    /// - Returns: Appropriate window border color
+    public static func windowBorder(for mode: ThemeMode) -> Color {
+        mode == .dark
+            ? Color("WindowBorder", bundle: .module)
+            : Color("WindowBorderLight", bundle: .module)
+    }
+
+    /// Close button color based on theme mode
+    /// - Parameter mode: The current theme mode (dark or light)
+    /// - Returns: Appropriate close button color
+    public static func editorCloseButton(for mode: ThemeMode) -> Color {
+        mode == .dark
+            ? Color("EditorCloseButton", bundle: .module)
+            : Color("EditorCloseButtonLight", bundle: .module)
+    }
 }

--- a/BifcodePackage/Sources/BifcodeFeature/Models/SettingsTypes.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Models/SettingsTypes.swift
@@ -246,13 +246,53 @@ public enum WindowLayout: String, CaseIterable, Sendable {
     }
 }
 
+// MARK: - Theme Mode
+
+/// The color mode for the code editor themes.
+///
+/// Controls whether dark or light themes are displayed in the theme picker.
+/// Users can toggle between modes, and the selected theme will switch to
+/// an equivalent theme in the new mode when available.
+///
+/// ## Usage
+///
+/// ```swift
+/// @AppStorage("themeMode") private var themeMode = ThemeMode.dark.rawValue
+/// ```
+///
+/// ## Topics
+///
+/// ### Modes
+///
+/// - ``dark``
+/// - ``light``
+public enum ThemeMode: String, CaseIterable, Sendable {
+    /// Dark mode themes with dark backgrounds.
+    ///
+    /// Ideal for low-light environments and reducing eye strain.
+    case dark
+
+    /// Light mode themes with light backgrounds.
+    ///
+    /// Better for bright environments and matching system light mode.
+    case light
+
+    /// A human-readable label for display in pickers.
+    public var label: String {
+        switch self {
+        case .dark: "Dark"
+        case .light: "Light"
+        }
+    }
+}
+
 // MARK: - Editor Themes
 
 /// Available syntax highlighting themes for the code editor.
 ///
 /// `EditorThemeOption` provides a curated selection of popular code editor
-/// themes. Each theme defines colors for text, keywords, strings, comments,
-/// and other syntax elements.
+/// themes in both dark and light variants. Each theme defines colors for text,
+/// keywords, strings, comments, and other syntax elements.
 ///
 /// ## Usage
 ///
@@ -267,6 +307,8 @@ public enum WindowLayout: String, CaseIterable, Sendable {
 ///
 /// ## Available Themes
 ///
+/// ### Dark Themes
+///
 /// | Theme | Description |
 /// |-------|-------------|
 /// | Atom One Dark | Popular dark theme from Atom editor |
@@ -277,9 +319,18 @@ public enum WindowLayout: String, CaseIterable, Sendable {
 /// | Solarized Dark | Solarized dark variant |
 /// | Xcode Default | macOS Xcode default dark theme |
 ///
+/// ### Light Themes
+///
+/// | Theme | Description |
+/// |-------|-------------|
+/// | Atom One Light | Light variant of Atom One |
+/// | GitHub Light | GitHub's official light mode |
+/// | Solarized Light | Solarized light variant |
+/// | Xcode Light | macOS Xcode default light theme |
+///
 /// ## Topics
 ///
-/// ### Themes
+/// ### Dark Themes
 ///
 /// - ``atomOneDark``
 /// - ``dracula``
@@ -289,11 +340,23 @@ public enum WindowLayout: String, CaseIterable, Sendable {
 /// - ``solarizedDark``
 /// - ``xcodeDefault``
 ///
+/// ### Light Themes
+///
+/// - ``atomOneLight``
+/// - ``githubLight``
+/// - ``solarizedLight``
+/// - ``xcodeLight``
+///
 /// ### Accessing Theme Data
 ///
 /// - ``label``
 /// - ``editorTheme``
+/// - ``mode``
+/// - ``themes(for:)``
+/// - ``equivalent(in:)``
 public enum EditorThemeOption: String, CaseIterable, Sendable {
+    // MARK: - Dark Themes
+
     /// Atom One Dark theme.
     ///
     /// A popular dark theme originally from the Atom editor.
@@ -338,6 +401,32 @@ public enum EditorThemeOption: String, CaseIterable, Sendable {
     /// Xcode syntax coloring.
     case xcodeDefault = "xcode-default"
 
+    // MARK: - Light Themes
+
+    /// Atom One Light theme.
+    ///
+    /// The light variant of the popular Atom One theme.
+    /// Features a light gray background with readable syntax colors.
+    case atomOneLight = "atom-one-light"
+
+    /// GitHub Light theme.
+    ///
+    /// GitHub's official light mode color scheme.
+    /// Features a white background with familiar GitHub coloring.
+    case githubLight = "github-light"
+
+    /// Solarized Light theme.
+    ///
+    /// The light variant of the Solarized color scheme.
+    /// Features a cream-colored background with warm tones.
+    case solarizedLight = "solarized-light"
+
+    /// Xcode Default Light theme.
+    ///
+    /// The default light theme from Apple's Xcode.
+    /// Features a white background with familiar Xcode syntax coloring.
+    case xcodeLight = "xcode-light"
+
     /// A human-readable label for display in pickers.
     public var label: String {
         switch self {
@@ -348,6 +437,66 @@ public enum EditorThemeOption: String, CaseIterable, Sendable {
         case .nord: "Nord"
         case .solarizedDark: "Solarized Dark"
         case .xcodeDefault: "Xcode Default"
+        case .atomOneLight: "Atom One Light"
+        case .githubLight: "GitHub Light"
+        case .solarizedLight: "Solarized Light"
+        case .xcodeLight: "Xcode Light"
+        }
+    }
+
+    /// The theme mode (dark or light).
+    ///
+    /// Use this to filter themes by mode in the UI.
+    public var mode: ThemeMode {
+        switch self {
+        case .atomOneDark, .dracula, .githubDark, .monokai, .nord, .solarizedDark, .xcodeDefault:
+            .dark
+        case .atomOneLight, .githubLight, .solarizedLight, .xcodeLight:
+            .light
+        }
+    }
+
+    /// Returns all themes for a specific mode.
+    ///
+    /// Use this to filter the theme picker based on the current mode:
+    ///
+    /// ```swift
+    /// let darkThemes = EditorThemeOption.themes(for: .dark)
+    /// let lightThemes = EditorThemeOption.themes(for: .light)
+    /// ```
+    ///
+    /// - Parameter mode: The theme mode to filter by.
+    /// - Returns: An array of themes matching the specified mode.
+    public static func themes(for mode: ThemeMode) -> [EditorThemeOption] {
+        allCases.filter { $0.mode == mode }
+    }
+
+    /// Returns the equivalent theme in the target mode, if available.
+    ///
+    /// When switching between dark and light modes, this method finds
+    /// the corresponding theme variant. For themes without an equivalent
+    /// (like Dracula or Monokai), returns `nil`.
+    ///
+    /// ```swift
+    /// let darkTheme = EditorThemeOption.atomOneDark
+    /// let lightEquivalent = darkTheme.equivalent(in: .light) // .atomOneLight
+    /// ```
+    ///
+    /// - Parameter targetMode: The mode to find an equivalent theme in.
+    /// - Returns: The equivalent theme, or `nil` if none exists.
+    public func equivalent(in targetMode: ThemeMode) -> EditorThemeOption? {
+        guard mode != targetMode else { return self }
+
+        switch self {
+        case .atomOneDark: return .atomOneLight
+        case .atomOneLight: return .atomOneDark
+        case .githubDark: return .githubLight
+        case .githubLight: return .githubDark
+        case .solarizedDark: return .solarizedLight
+        case .solarizedLight: return .solarizedDark
+        case .xcodeDefault: return .xcodeLight
+        case .xcodeLight: return .xcodeDefault
+        case .dracula, .monokai, .nord: return nil
         }
     }
 
@@ -369,6 +518,10 @@ public enum EditorThemeOption: String, CaseIterable, Sendable {
         case .nord: .nord
         case .solarizedDark: .solarizedDark
         case .xcodeDefault: .xcodeDefault
+        case .atomOneLight: .atomOneLight
+        case .githubLight: .githubLight
+        case .solarizedLight: .solarizedLight
+        case .xcodeLight: .xcodeLight
         }
     }
 }
@@ -545,5 +698,99 @@ extension EditorTheme {
         strings: .init(color: NSColor(red: 0.99, green: 0.42, blue: 0.36, alpha: 1.0)),
         characters: .init(color: NSColor(red: 0.82, green: 0.62, blue: 0.99, alpha: 1.0)),
         comments: .init(color: NSColor(red: 0.42, green: 0.48, blue: 0.51, alpha: 1.0))
+    )
+
+    // MARK: - Light Theme Presets
+
+    /// Atom One Light theme preset.
+    ///
+    /// The light variant of Atom One with a `#fafafa` background
+    /// and readable syntax colors.
+    public nonisolated(unsafe) static let atomOneLight = EditorTheme(
+        text: .init(color: NSColor(red: 0.22, green: 0.23, blue: 0.26, alpha: 1.0)), // #383a42
+        insertionPoint: .black,
+        invisibles: .init(color: NSColor(white: 0.8, alpha: 1.0)),
+        background: NSColor(red: 0.98, green: 0.98, blue: 0.98, alpha: 1.0), // #fafafa
+        lineHighlight: NSColor.clear,
+        selection: NSColor(red: 0.90, green: 0.91, blue: 0.92, alpha: 1.0),
+        keywords: .init(color: NSColor(red: 0.65, green: 0.15, blue: 0.64, alpha: 1.0)), // #a626a4
+        commands: .init(color: NSColor(red: 0.25, green: 0.43, blue: 0.77, alpha: 1.0)), // #4078f2
+        types: .init(color: NSColor(red: 0.76, green: 0.49, blue: 0.0, alpha: 1.0)), // #c18401
+        attributes: .init(color: NSColor(red: 0.76, green: 0.49, blue: 0.0, alpha: 1.0)),
+        variables: .init(color: NSColor(red: 0.90, green: 0.25, blue: 0.21, alpha: 1.0)), // #e45649
+        values: .init(color: NSColor(red: 0.60, green: 0.40, blue: 0.0, alpha: 1.0)), // #986801
+        numbers: .init(color: NSColor(red: 0.60, green: 0.40, blue: 0.0, alpha: 1.0)),
+        strings: .init(color: NSColor(red: 0.31, green: 0.63, blue: 0.31, alpha: 1.0)), // #50a14f
+        characters: .init(color: NSColor(red: 0.31, green: 0.63, blue: 0.31, alpha: 1.0)),
+        comments: .init(color: NSColor(red: 0.63, green: 0.63, blue: 0.65, alpha: 1.0)) // #a0a1a7
+    )
+
+    /// GitHub Light theme preset.
+    ///
+    /// GitHub's official light mode color scheme with a `#ffffff`
+    /// background and familiar GitHub coloring.
+    public nonisolated(unsafe) static let githubLight = EditorTheme(
+        text: .init(color: NSColor(red: 0.14, green: 0.16, blue: 0.18, alpha: 1.0)), // #24292e
+        insertionPoint: .black,
+        invisibles: .init(color: NSColor(white: 0.8, alpha: 1.0)),
+        background: NSColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0), // #ffffff
+        lineHighlight: NSColor.clear,
+        selection: NSColor(red: 0.88, green: 0.93, blue: 0.98, alpha: 1.0),
+        keywords: .init(color: NSColor(red: 0.84, green: 0.23, blue: 0.29, alpha: 1.0)), // #d73a49
+        commands: .init(color: NSColor(red: 0.44, green: 0.26, blue: 0.69, alpha: 1.0)), // #6f42c1
+        types: .init(color: NSColor(red: 0.44, green: 0.26, blue: 0.69, alpha: 1.0)),
+        attributes: .init(color: NSColor(red: 0.44, green: 0.26, blue: 0.69, alpha: 1.0)),
+        variables: .init(color: NSColor(red: 0.14, green: 0.16, blue: 0.18, alpha: 1.0)),
+        values: .init(color: NSColor(red: 0.0, green: 0.36, blue: 0.58, alpha: 1.0)), // #005cc5
+        numbers: .init(color: NSColor(red: 0.0, green: 0.36, blue: 0.58, alpha: 1.0)),
+        strings: .init(color: NSColor(red: 0.01, green: 0.18, blue: 0.38, alpha: 1.0)), // #032f62
+        characters: .init(color: NSColor(red: 0.01, green: 0.18, blue: 0.38, alpha: 1.0)),
+        comments: .init(color: NSColor(red: 0.42, green: 0.45, blue: 0.49, alpha: 1.0)) // #6a737d
+    )
+
+    /// Solarized Light theme preset.
+    ///
+    /// The light variant of Solarized with a cream-colored `#fdf6e3`
+    /// background and carefully balanced colors.
+    public nonisolated(unsafe) static let solarizedLight = EditorTheme(
+        text: .init(color: NSColor(red: 0.40, green: 0.48, blue: 0.51, alpha: 1.0)), // #657b83
+        insertionPoint: .black,
+        invisibles: .init(color: NSColor(white: 0.8, alpha: 1.0)),
+        background: NSColor(red: 0.99, green: 0.96, blue: 0.89, alpha: 1.0), // #fdf6e3
+        lineHighlight: NSColor.clear,
+        selection: NSColor(red: 0.93, green: 0.91, blue: 0.84, alpha: 1.0),
+        keywords: .init(color: NSColor(red: 0.52, green: 0.60, blue: 0.0, alpha: 1.0)), // #859900
+        commands: .init(color: NSColor(red: 0.15, green: 0.55, blue: 0.82, alpha: 1.0)), // #268bd2
+        types: .init(color: NSColor(red: 0.71, green: 0.54, blue: 0.0, alpha: 1.0)), // #b58900
+        attributes: .init(color: NSColor(red: 0.71, green: 0.54, blue: 0.0, alpha: 1.0)),
+        variables: .init(color: NSColor(red: 0.15, green: 0.55, blue: 0.82, alpha: 1.0)),
+        values: .init(color: NSColor(red: 0.16, green: 0.63, blue: 0.60, alpha: 1.0)), // #2aa198
+        numbers: .init(color: NSColor(red: 0.16, green: 0.63, blue: 0.60, alpha: 1.0)),
+        strings: .init(color: NSColor(red: 0.16, green: 0.63, blue: 0.60, alpha: 1.0)),
+        characters: .init(color: NSColor(red: 0.16, green: 0.63, blue: 0.60, alpha: 1.0)),
+        comments: .init(color: NSColor(red: 0.58, green: 0.63, blue: 0.63, alpha: 1.0)) // #93a1a1
+    )
+
+    /// Xcode Default Light theme preset.
+    ///
+    /// Apple's default light theme for Xcode with a `#ffffff`
+    /// background and familiar Xcode syntax coloring.
+    public nonisolated(unsafe) static let xcodeLight = EditorTheme(
+        text: .init(color: NSColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)), // #000000
+        insertionPoint: .black,
+        invisibles: .init(color: NSColor(white: 0.8, alpha: 1.0)),
+        background: NSColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0), // #ffffff
+        lineHighlight: NSColor.clear,
+        selection: NSColor(red: 0.73, green: 0.84, blue: 0.95, alpha: 1.0),
+        keywords: .init(color: NSColor(red: 0.68, green: 0.24, blue: 0.64, alpha: 1.0)), // #ad3da4
+        commands: .init(color: NSColor(red: 0.11, green: 0.43, blue: 0.47, alpha: 1.0)), // #1c6b72
+        types: .init(color: NSColor(red: 0.11, green: 0.38, blue: 0.56, alpha: 1.0)), // #1c5f8f
+        attributes: .init(color: NSColor(red: 0.59, green: 0.40, blue: 0.15, alpha: 1.0)), // #976726
+        variables: .init(color: NSColor(red: 0.11, green: 0.43, blue: 0.47, alpha: 1.0)),
+        values: .init(color: NSColor(red: 0.11, green: 0.15, blue: 0.73, alpha: 1.0)), // #1c26ba
+        numbers: .init(color: NSColor(red: 0.11, green: 0.15, blue: 0.73, alpha: 1.0)),
+        strings: .init(color: NSColor(red: 0.82, green: 0.12, blue: 0.11, alpha: 1.0)), // #d12f1b
+        characters: .init(color: NSColor(red: 0.11, green: 0.15, blue: 0.73, alpha: 1.0)),
+        comments: .init(color: NSColor(red: 0.36, green: 0.42, blue: 0.47, alpha: 1.0)) // #5d6c79
     )
 }

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/EditorCloseButtonLight.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/EditorCloseButtonLight.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.250",
+          "green" : "0.250",
+          "red" : "0.850"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/TitleBarBackgroundLight.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/TitleBarBackgroundLight.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.920",
+          "green" : "0.920",
+          "red" : "0.915"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/TitleTextLight.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/TitleTextLight.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.200",
+          "red" : "0.200"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/WindowBorderLight.colorset/Contents.json
+++ b/BifcodePackage/Sources/BifcodeFeature/Resources/Colors.xcassets/WindowBorderLight.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.800",
+          "green" : "0.800",
+          "red" : "0.800"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Views/CodeEditorView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/CodeEditorView.swift
@@ -76,6 +76,7 @@ public struct CodeEditorView: View {
     @AppStorage("showTitle") private var showTitle: Bool = true
     @AppStorage("fontSize") private var fontSize: Double = 14
     @AppStorage("selectedTheme") private var selectedThemeRaw: String = EditorThemeOption.atomOneDark.rawValue
+    @AppStorage("themeMode") private var themeModeRaw: String = ThemeMode.dark.rawValue
 
     private var indicatorPosition: IndicatorPosition {
         IndicatorPosition(rawValue: indicatorPositionRaw) ?? .topRight
@@ -87,6 +88,10 @@ public struct CodeEditorView: View {
 
     private var selectedTheme: EditorThemeOption {
         EditorThemeOption(rawValue: selectedThemeRaw) ?? .atomOneDark
+    }
+
+    private var themeMode: ThemeMode {
+        ThemeMode(rawValue: themeModeRaw) ?? .dark
     }
 
     /// Creates a new code editor view for the specified panel.
@@ -124,7 +129,7 @@ public struct CodeEditorView: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .stroke(Color.windowBorder, lineWidth: 1)
+                .stroke(Color.windowBorder(for: themeMode), lineWidth: 1)
         )
     }
 
@@ -150,13 +155,13 @@ public struct CodeEditorView: View {
         HStack(spacing: 14) {
             // Traffic light placeholder
             Circle()
-                .fill(Color.editorCloseButton)
+                .fill(Color.editorCloseButton(for: themeMode))
                 .frame(width: 14, height: 14)
 
             // Title - single line with truncation
             Label(panel.title, systemImage: "text.document.fill")
                 .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(Color.titleText)
+                .foregroundStyle(Color.titleText(for: themeMode))
                 .lineLimit(1)
                 .truncationMode(.tail)
 
@@ -165,7 +170,7 @@ public struct CodeEditorView: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity)
-        .background(Color.titleBarBackground)
+        .background(Color.titleBarBackground(for: themeMode))
         .clipShape(UnevenRoundedRectangle(topLeadingRadius: 12, topTrailingRadius: 12))
     }
 

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ExportPanelView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ExportPanelView.swift
@@ -63,6 +63,9 @@ struct ExportPanelView: View {
     /// The syntax highlighting theme.
     let theme: EditorTheme
 
+    /// The current theme mode for window styling.
+    let themeMode: ThemeMode
+
     /// Local editor state (not shared with interactive editor).
     @State private var editorState = SourceEditorState()
 
@@ -80,7 +83,7 @@ struct ExportPanelView: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .stroke(Color.windowBorder, lineWidth: 1)
+                .stroke(Color.windowBorder(for: themeMode), lineWidth: 1)
         )
     }
 
@@ -90,13 +93,13 @@ struct ExportPanelView: View {
         HStack(spacing: 14) {
             // Traffic light placeholder
             Circle()
-                .fill(Color.editorCloseButton)
+                .fill(Color.editorCloseButton(for: themeMode))
                 .frame(width: 14, height: 14)
 
             // Title - single line with truncation
             Label(panel.title, systemImage: "text.document.fill")
                 .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(Color.titleText)
+                .foregroundStyle(Color.titleText(for: themeMode))
                 .lineLimit(1)
                 .truncationMode(.tail)
 
@@ -105,7 +108,7 @@ struct ExportPanelView: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity)
-        .background(Color.titleBarBackground)
+        .background(Color.titleBarBackground(for: themeMode))
         .clipShape(UnevenRoundedRectangle(topLeadingRadius: 12, topTrailingRadius: 12))
     }
 
@@ -179,7 +182,8 @@ struct ExportPanelView: View {
         indicatorLabel: "Do's",
         showTitle: true,
         fontSize: 14,
-        theme: .atomOneDark
+        theme: .atomOneDark,
+        themeMode: .dark
     )
     .frame(width: 400, height: 200)
     .padding()
@@ -203,7 +207,8 @@ struct ExportPanelView: View {
         indicatorLabel: "Don'ts",
         showTitle: true,
         fontSize: 14,
-        theme: .atomOneDark
+        theme: .atomOneDark,
+        themeMode: .dark
     )
     .frame(width: 400, height: 200)
     .padding()

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ExportView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ExportView.swift
@@ -66,6 +66,9 @@ struct ExportView: View {
     /// The syntax highlighting theme.
     let theme: EditorTheme
 
+    /// The current theme mode for window styling.
+    let themeMode: ThemeMode
+
     // Panel dimensions for export
 
     /// Width of each panel in points.
@@ -104,7 +107,8 @@ struct ExportView: View {
             indicatorLabel: dontIndicatorLabel,
             showTitle: showTitle,
             fontSize: fontSize,
-            theme: theme
+            theme: theme,
+            themeMode: themeMode
         )
         .frame(width: panelWidth, height: dontPanelHeight)
         .shadow(color: .black.opacity(0.3), radius: 12, x: 0, y: 4)
@@ -118,7 +122,8 @@ struct ExportView: View {
             indicatorLabel: doIndicatorLabel,
             showTitle: showTitle,
             fontSize: fontSize,
-            theme: theme
+            theme: theme,
+            themeMode: themeMode
         )
         .frame(width: panelWidth, height: doPanelHeight)
         .shadow(color: .black.opacity(0.3), radius: 12, x: 0, y: 4)
@@ -154,6 +159,7 @@ struct ExportView: View {
         showTitle: true,
         fontSize: 14,
         theme: .atomOneDark,
+        themeMode: .dark,
         panelWidth: 350,
         doPanelHeight: 120,
         dontPanelHeight: 120
@@ -188,6 +194,7 @@ struct ExportView: View {
         showTitle: true,
         fontSize: 14,
         theme: .atomOneDark,
+        themeMode: .dark,
         panelWidth: 400,
         doPanelHeight: 120,
         dontPanelHeight: 120

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
@@ -58,6 +58,7 @@ public struct ToolBarView: View {
     @AppStorage("dontIndicatorLabel") private var dontIndicatorLabel: String = "Don'ts"
     @AppStorage("fontSize") private var fontSize: Double = 14
     @AppStorage("selectedTheme") private var selectedThemeRaw: String = EditorThemeOption.atomOneDark.rawValue
+    @AppStorage("themeMode") private var themeModeRaw: String = ThemeMode.dark.rawValue
 
     @AppStorage("selectedLanguage") private var selectedLanguageRaw: String = "swift"
 
@@ -69,6 +70,21 @@ public struct ToolBarView: View {
     /// Selected language derived from stored raw value
     private var selectedLanguage: CodeLanguage {
         CodeLanguage.allLanguages.first { $0.id.rawValue == selectedLanguageRaw } ?? .swift
+    }
+
+    /// Current theme mode derived from stored raw value
+    private var currentThemeMode: ThemeMode {
+        ThemeMode(rawValue: themeModeRaw) ?? .dark
+    }
+
+    /// Current selected theme derived from stored raw value
+    private var currentTheme: EditorThemeOption {
+        EditorThemeOption(rawValue: selectedThemeRaw) ?? .atomOneDark
+    }
+
+    /// All available themes (not filtered by mode)
+    private var availableThemes: [EditorThemeOption] {
+        EditorThemeOption.allCases
     }
 
     @Binding private var doTitleSetting: String
@@ -123,12 +139,12 @@ public struct ToolBarView: View {
             codeSettingsView()
                 .padding(.trailing, 8)
 
-            Divider().frame(height: 150)
+            Divider().frame(height: 160)
 
             indicatorSettingsView()
                 .padding(.trailing, 8)
             
-            Divider().frame(height: 150)
+            Divider().frame(height: 160)
 
             Spacer(minLength: 0)
 
@@ -150,15 +166,9 @@ public struct ToolBarView: View {
             HStack(spacing: 8) {
                 // Language
                 languagePicker
-                
+
                 // Theme
                 themePicker
-                
-                Divider().frame(width: 1, height: 20)
-                    .padding(.leading, 8)
-                
-                // Layout
-                layoutToggle
             }
             .fixedSize()
             
@@ -166,16 +176,20 @@ public struct ToolBarView: View {
             fontSizeControl
             
             VStack(spacing: 16) {
-                Text("Panel Titles")
-                    .font(.caption)
-                    .foregroundStyle(Color.secondaryText)
+                HStack(spacing: 16) {
+                    // Theme Mode Toggle
+                    themeModeToggle
+                    
+                    // Layout
+                    layoutToggle
+                }
                 
                 HStack(spacing: 16) {
-                    doTitleField
                     dontTitleField
+                    
+                    doTitleField
                 }
             }
-            .padding(.top, 11)
             .frame(maxWidth: .infinity)
         }
         .fixedSize()
@@ -214,10 +228,10 @@ public struct ToolBarView: View {
 
             // Indicator Labels
             HStack(spacing: 8) {
-                doIndicatorLabelField
+                dontIndicatorLabelField
                     .padding(.horizontal, 8)
                     .frame(maxWidth: .infinity)
-                dontIndicatorLabelField
+                doIndicatorLabelField
                     .frame(maxWidth: .infinity)
             }
             .frame(maxWidth: .infinity)
@@ -251,11 +265,22 @@ public struct ToolBarView: View {
         ]
     }
 
+    // MARK: - Theme Mode Toggle
+
+    private var themeModeToggle: some View {
+        Picker("", selection: $themeModeRaw) {
+            Image(systemName: "moon.fill").tag(ThemeMode.dark.rawValue)
+            Image(systemName: "sun.max.fill").tag(ThemeMode.light.rawValue)
+        }
+        .pickerStyle(.segmented)
+        .fixedSize()
+    }
+
     // MARK: - Theme Picker
 
     private var themePicker: some View {
         Picker("", selection: $selectedThemeRaw) {
-            ForEach(EditorThemeOption.allCases, id: \.rawValue) { theme in
+            ForEach(availableThemes, id: \.rawValue) { theme in
                 Text(theme.label).tag(theme.rawValue)
             }
         }
@@ -390,7 +415,7 @@ public struct ToolBarView: View {
     private var doTitleField: some View {
         TextField("Do Title", text: $doTitleSetting)
             .textFieldStyle(.roundedBorder)
-            .frame(width: 150)
+            .frame(width: 128)
             .onChange(of: doTitleSetting) { _, newValue in
                 if newValue.count > 70 {
                     doTitleSetting = String(newValue.prefix(70))
@@ -401,7 +426,7 @@ public struct ToolBarView: View {
     private var dontTitleField: some View {
         TextField("Don't Title", text: $dontTitleSetting)
             .textFieldStyle(.roundedBorder)
-            .frame(width: 150)
+            .frame(width: 128)
             .onChange(of: dontTitleSetting) { _, newValue in
                 if newValue.count > 70 {
                     dontTitleSetting = String(newValue.prefix(70))

--- a/BifcodePackage/Tests/BifcodeFeatureTests/SettingsTypesTests.swift
+++ b/BifcodePackage/Tests/BifcodeFeatureTests/SettingsTypesTests.swift
@@ -493,13 +493,13 @@ struct EditorThemeOptionTests {
 
     // MARK: - CaseIterable
 
-    @Test("allCases contains exactly 7 themes")
+    @Test("allCases contains exactly 11 themes (7 dark + 4 light)")
     func allCasesCount() {
-        #expect(EditorThemeOption.allCases.count == 7)
+        #expect(EditorThemeOption.allCases.count == 11)
     }
 
-    @Test("allCases contains all themes")
-    func allCasesContains() {
+    @Test("allCases contains all dark themes")
+    func allCasesContainsDark() {
         #expect(EditorThemeOption.allCases.contains(.atomOneDark))
         #expect(EditorThemeOption.allCases.contains(.dracula))
         #expect(EditorThemeOption.allCases.contains(.githubDark))
@@ -507,6 +507,14 @@ struct EditorThemeOptionTests {
         #expect(EditorThemeOption.allCases.contains(.nord))
         #expect(EditorThemeOption.allCases.contains(.solarizedDark))
         #expect(EditorThemeOption.allCases.contains(.xcodeDefault))
+    }
+
+    @Test("allCases contains all light themes")
+    func allCasesContainsLight() {
+        #expect(EditorThemeOption.allCases.contains(.atomOneLight))
+        #expect(EditorThemeOption.allCases.contains(.githubLight))
+        #expect(EditorThemeOption.allCases.contains(.solarizedLight))
+        #expect(EditorThemeOption.allCases.contains(.xcodeLight))
     }
 
     // MARK: - Initialization from Raw Value
@@ -548,12 +556,194 @@ struct EditorThemeOptionTests {
         #expect(background != nil)
     }
 
-    @Test("each theme option maps to unique EditorTheme")
+    @Test("each theme option maps to distinct EditorTheme")
     func uniqueThemeMappings() {
-        // Verify themes are distinct by checking backgrounds
+        // Verify themes have distinct styling (some themes may share background colors)
+        // GitHub Light and Xcode Light both use white (#ffffff) backgrounds
         let backgrounds = EditorThemeOption.allCases.map(\.editorTheme.background)
         let uniqueBackgrounds = Set(backgrounds.map(\.description))
-        // All 7 themes should have unique backgrounds
-        #expect(uniqueBackgrounds.count == 7)
+        // At least 10 unique backgrounds (githubLight and xcodeLight share white)
+        #expect(uniqueBackgrounds.count >= 10)
+    }
+
+    // MARK: - Theme Mode
+
+    @Test("dark themes have dark mode")
+    func darkThemesHaveDarkMode() {
+        #expect(EditorThemeOption.atomOneDark.mode == .dark)
+        #expect(EditorThemeOption.dracula.mode == .dark)
+        #expect(EditorThemeOption.githubDark.mode == .dark)
+        #expect(EditorThemeOption.monokai.mode == .dark)
+        #expect(EditorThemeOption.nord.mode == .dark)
+        #expect(EditorThemeOption.solarizedDark.mode == .dark)
+        #expect(EditorThemeOption.xcodeDefault.mode == .dark)
+    }
+
+    @Test("light themes have light mode")
+    func lightThemesHaveLightMode() {
+        #expect(EditorThemeOption.atomOneLight.mode == .light)
+        #expect(EditorThemeOption.githubLight.mode == .light)
+        #expect(EditorThemeOption.solarizedLight.mode == .light)
+        #expect(EditorThemeOption.xcodeLight.mode == .light)
+    }
+
+    @Test("themes(for: .dark) returns only dark themes")
+    func themesForDark() {
+        let darkThemes = EditorThemeOption.themes(for: .dark)
+        #expect(darkThemes.count == 7)
+        for theme in darkThemes {
+            #expect(theme.mode == .dark)
+        }
+    }
+
+    @Test("themes(for: .light) returns only light themes")
+    func themesForLight() {
+        let lightThemes = EditorThemeOption.themes(for: .light)
+        #expect(lightThemes.count == 4)
+        for theme in lightThemes {
+            #expect(theme.mode == .light)
+        }
+    }
+
+    // MARK: - Theme Equivalence
+
+    @Test("atomOneDark equivalent in light is atomOneLight")
+    func atomOneDarkEquivalent() {
+        #expect(EditorThemeOption.atomOneDark.equivalent(in: .light) == .atomOneLight)
+    }
+
+    @Test("atomOneLight equivalent in dark is atomOneDark")
+    func atomOneLightEquivalent() {
+        #expect(EditorThemeOption.atomOneLight.equivalent(in: .dark) == .atomOneDark)
+    }
+
+    @Test("githubDark equivalent in light is githubLight")
+    func githubDarkEquivalent() {
+        #expect(EditorThemeOption.githubDark.equivalent(in: .light) == .githubLight)
+    }
+
+    @Test("solarizedDark equivalent in light is solarizedLight")
+    func solarizedDarkEquivalent() {
+        #expect(EditorThemeOption.solarizedDark.equivalent(in: .light) == .solarizedLight)
+    }
+
+    @Test("xcodeDefault equivalent in light is xcodeLight")
+    func xcodeDefaultEquivalent() {
+        #expect(EditorThemeOption.xcodeDefault.equivalent(in: .light) == .xcodeLight)
+    }
+
+    @Test("dracula has no light equivalent")
+    func draculaNoEquivalent() {
+        #expect(EditorThemeOption.dracula.equivalent(in: .light) == nil)
+    }
+
+    @Test("monokai has no light equivalent")
+    func monokaiNoEquivalent() {
+        #expect(EditorThemeOption.monokai.equivalent(in: .light) == nil)
+    }
+
+    @Test("nord has no light equivalent")
+    func nordNoEquivalent() {
+        #expect(EditorThemeOption.nord.equivalent(in: .light) == nil)
+    }
+
+    @Test("equivalent in same mode returns self")
+    func equivalentInSameModeReturnsSelf() {
+        #expect(EditorThemeOption.atomOneDark.equivalent(in: .dark) == .atomOneDark)
+        #expect(EditorThemeOption.atomOneLight.equivalent(in: .light) == .atomOneLight)
+    }
+
+    // MARK: - Light Theme Labels
+
+    @Test("label returns 'Atom One Light' for atomOneLight")
+    func labelAtomOneLight() {
+        #expect(EditorThemeOption.atomOneLight.label == "Atom One Light")
+    }
+
+    @Test("label returns 'GitHub Light' for githubLight")
+    func labelGithubLight() {
+        #expect(EditorThemeOption.githubLight.label == "GitHub Light")
+    }
+
+    @Test("label returns 'Solarized Light' for solarizedLight")
+    func labelSolarizedLight() {
+        #expect(EditorThemeOption.solarizedLight.label == "Solarized Light")
+    }
+
+    @Test("label returns 'Xcode Light' for xcodeLight")
+    func labelXcodeLight() {
+        #expect(EditorThemeOption.xcodeLight.label == "Xcode Light")
+    }
+}
+
+// MARK: - ThemeMode Tests
+
+@Suite("ThemeMode Tests")
+struct ThemeModeTests {
+    // MARK: - Raw Values
+
+    @Test("rawValue returns 'dark' for dark")
+    func rawValueDark() {
+        #expect(ThemeMode.dark.rawValue == "dark")
+    }
+
+    @Test("rawValue returns 'light' for light")
+    func rawValueLight() {
+        #expect(ThemeMode.light.rawValue == "light")
+    }
+
+    // MARK: - Labels
+
+    @Test("label returns 'Dark' for dark")
+    func labelDark() {
+        #expect(ThemeMode.dark.label == "Dark")
+    }
+
+    @Test("label returns 'Light' for light")
+    func labelLight() {
+        #expect(ThemeMode.light.label == "Light")
+    }
+
+    // MARK: - CaseIterable
+
+    @Test("allCases contains exactly 2 modes")
+    func allCasesCount() {
+        #expect(ThemeMode.allCases.count == 2)
+    }
+
+    @Test("allCases contains dark and light")
+    func allCasesContains() {
+        #expect(ThemeMode.allCases.contains(.dark))
+        #expect(ThemeMode.allCases.contains(.light))
+    }
+
+    // MARK: - Initialization from Raw Value
+
+    @Test("init from 'dark' returns dark")
+    func initFromRawValueDark() {
+        let mode = ThemeMode(rawValue: "dark")
+        #expect(mode == .dark)
+    }
+
+    @Test("init from 'light' returns light")
+    func initFromRawValueLight() {
+        let mode = ThemeMode(rawValue: "light")
+        #expect(mode == .light)
+    }
+
+    @Test("init from invalid rawValue returns nil")
+    func initFromInvalidRawValue() {
+        let mode = ThemeMode(rawValue: "auto")
+        #expect(mode == nil)
+    }
+
+    // MARK: - Sendable Conformance
+
+    @Test("ThemeMode is Sendable")
+    func sendableConformance() async {
+        let mode = ThemeMode.dark
+        await Task.detached {
+            _ = mode.rawValue
+        }.value
     }
 }


### PR DESCRIPTION
## Summary

Adds ThemeMode enum (dark/light) to independently control panel window styling separate from syntax highlighting theme. When user toggles theme mode, title bar background, title text, border, and close button colors update immediately across all panels.

## Changes

- New ThemeMode enum with dark/light modes
- 4 new light mode color assets for panel chrome
- Theme-aware color functions in Color+Semantic.swift
- Theme mode toggle in toolbar UI
- Theme mode applied to all panel views

## Notes

Theme mode and syntax highlighting theme are independent—users can select any syntax theme with any panel styling theme.