### PR TITLE
feat: add in-app purchases with DeveloperSupportStore

### DIFF
--- a/BifcodePackage/Package.swift
+++ b/BifcodePackage/Package.swift
@@ -13,12 +13,14 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/CodeEditApp/CodeEditSourceEditor", from: "0.12.0"),
+        .package(url: "https://github.com/IGRSoft/DeveloperSupportStore", from: "1.0.0"),
     ],
     targets: [
         .target(
             name: "BifcodeFeature",
             dependencies: [
                 .product(name: "CodeEditSourceEditor", package: "CodeEditSourceEditor"),
+                .product(name: "DeveloperSupportStore", package: "DeveloperSupportStore"),
             ],
             resources: [
                 .process("Resources"),

--- a/BifcodePackage/Sources/BifcodeFeature/Configuration/BifcodeStoreConfiguration.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Configuration/BifcodeStoreConfiguration.swift
@@ -1,0 +1,23 @@
+//
+//  BifcodeStoreConfiguration.swift
+//
+//  Created on 22.12.2025.
+//  Copyright © 2025 IGR Soft. All rights reserved.
+//
+
+import DeveloperSupportStore
+import Foundation
+
+/// Store configuration for Bifcode app.
+/// Product IDs are loaded automatically from Products.plist by StoreHelper.
+public struct BifcodeStoreConfiguration: StoreConfigurationProtocol {
+    public var privacyPolicyURL: URL {
+        URL(string: "https://igrsoft.com/info/app/bifcode/policy.html")!
+    }
+
+    public var termsOfUseURL: URL {
+        URL(string: "https://igrsoft.com/info/app/bifcode/terms.html")!
+    }
+
+    public init() {}
+}

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
@@ -7,6 +7,7 @@
 
 import CodeEditLanguages
 import CodeEditSourceEditor
+import DeveloperSupportStore
 import SwiftUI
 
 /// A toolbar providing all code style and indicator settings with an export button.
@@ -437,6 +438,14 @@ public struct ToolBarView: View {
     // MARK: - Export Button
 
     @State private var isExportButtonHovered = false
+    @State private var isStorePresented = false
+
+    /// Tracks whether the user has made any purchase (subscription or tip).
+    /// Persisted via AppStorage so the green icon state survives app restarts.
+    @AppStorage("hasMadePurchase") private var hasMadePurchase = false
+
+    private let storeConfiguration = BifcodeStoreConfiguration()
+    private let storeService = StoreService()
 
     private var exportButton: some View {
         VStack(spacing: 16) {
@@ -457,6 +466,48 @@ public struct ToolBarView: View {
             Button("Choose") {
                 chooseSaveLocation()
             }
+
+            storeButton
+        }
+    }
+
+    private var storeButton: some View {
+        Button {
+            isStorePresented = true
+        } label: {
+            Image(systemName: "storefront")
+                .font(.system(size: 16))
+        }
+        .foregroundStyle(hasMadePurchase ? .green : .secondary)
+        .sheet(isPresented: $isStorePresented) {
+            DeveloperSupportStoreView(
+                configuration: storeConfiguration,
+                storeService: storeService,
+                onPurchaseSuccess: { _ in
+                    hasMadePurchase = true
+                },
+                onDismiss: {
+                    isStorePresented = false
+                }
+            )
+        }
+        .task {
+            await checkPurchaseStatus()
+        }
+    }
+
+    private func checkPurchaseStatus() async {
+        // Skip sync if user has already made a purchase (persisted via AppStorage)
+        guard !hasMadePurchase else { return }
+
+        do {
+            try await storeService.syncStoreData()
+            // Check if there's an active subscription
+            if storeService.hasActiveSubscription {
+                hasMadePurchase = true
+            }
+        } catch {
+            // Silently fail - purchase status will remain false
         }
     }
     


### PR DESCRIPTION
Adds in-app purchase support for subscriptions and tips.

## Features
- Store button below Choose button in toolbar
- Opens sheet with subscription and one-time purchase options  
- Icon turns green when user has made a purchase
- Purchase state persists across app restarts
- Syncs with App Store to check for active subscriptions

## Changes
- Add DeveloperSupportStore package dependency
- Create BifcodeStoreConfiguration for privacy/terms URLs
- Add store button to ToolBarView with purchase tracking