### PR TITLE
feat: add toast notification on export with Finder reveal

### DIFF
--- a/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/ContentView.swift
@@ -63,6 +63,9 @@ import SwiftUI
 /// - ``IndicatorStyle``
 public struct ContentView: View {
     @State private var viewModel = AppViewModel()
+    @State private var exportResult: ExportResult?
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     // Language is stored via @AppStorage in ToolBarView, we read it here to initialize panels
     @AppStorage("selectedLanguage") private var selectedLanguageRaw: String = "swift"
@@ -118,17 +121,30 @@ public struct ContentView: View {
     }
 
     public var body: some View {
-        VStack(spacing: 0) {
-            ToolBarView(
-                doTitleSetting: $doTitleSetting,
-                dontTitleSetting: $dontTitleSetting,
-                isExportDisabled: isCodeEmpty,
-                onExport: { Task(operation: exportImage) },
-                onLanguageChange: { viewModel.setLanguage($0) }
-            )
+        ZStack(alignment: .top) {
+            VStack(spacing: 0) {
+                ToolBarView(
+                    doTitleSetting: $doTitleSetting,
+                    dontTitleSetting: $dontTitleSetting,
+                    isExportDisabled: isCodeEmpty,
+                    onExport: { Task(operation: exportImage) },
+                    onLanguageChange: { viewModel.setLanguage($0) }
+                )
 
-            panelsView
-                .padding(16)
+                panelsView
+                    .padding(16)
+            }
+
+            // Toast overlay at top of toolbar
+            if let result = exportResult {
+                ToastView(result: result) {
+                    withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.25)) {
+                        exportResult = nil
+                    }
+                }
+                .padding(.top, 8)
+                .zIndex(100)
+            }
         }
         .background(Color.contentBackground)
         .frame(minHeight: 400)
@@ -220,6 +236,7 @@ public struct ContentView: View {
     /// This method orchestrates the export pipeline:
     /// 1. Renders the panels to an `NSImage` via ``renderExportViewToImage()``
     /// 2. Saves the image using ``AppViewModel/saveImage(_:)``
+    /// 3. Displays a toast notification with the result
     ///
     /// > Note: Export is disabled when both code panels are empty.
     @MainActor
@@ -227,16 +244,21 @@ public struct ContentView: View {
         // Use NSHostingView + snapshot instead of ImageRenderer
         // because ImageRenderer cannot render NSViewRepresentable views like SourceEditor
         guard let nsImage = await renderExportViewToImage() else {
-            // TODO: Show error alert
-            print("Export failed: Could not render view to image")
+            withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.25)) {
+                exportResult = .failure(ExportError.conversionFailed)
+            }
             return
         }
 
         do {
-            try await viewModel.saveImage(nsImage)
+            let savedURL = try await viewModel.saveImage(nsImage)
+            withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.25)) {
+                exportResult = .success(savedURL)
+            }
         } catch {
-            // TODO: Show error alert
-            print("Export failed: \(error.localizedDescription)")
+            withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.25)) {
+                exportResult = .failure(error)
+            }
         }
     }
 

--- a/BifcodePackage/Sources/BifcodeFeature/Extensions/Color+Semantic.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Extensions/Color+Semantic.swift
@@ -159,6 +159,14 @@ extension Color {
         Color.accentColor
     }
 
+    // MARK: - Toast Colors
+
+    /// Toast success background - uses semantic green
+    public static let toastSuccess = Color("IndicatorDo", bundle: .module)
+
+    /// Toast error background - uses semantic red
+    public static let toastError = Color("IndicatorDont", bundle: .module)
+
     // MARK: - Theme Mode Aware Colors
 
     /// Title bar background based on theme mode

--- a/BifcodePackage/Sources/BifcodeFeature/ViewModels/AppViewModel.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/ViewModels/AppViewModel.swift
@@ -149,8 +149,10 @@ public final class AppViewModel {
     ///
     /// Handles security-scoped resource access for bookmarked locations.
     /// - Parameter image: The NSImage to save as PNG
+    /// - Returns: The URL where the image was saved
     /// - Throws: `ExportError` if conversion or saving fails
-    public func saveImage(_ image: NSImage) async throws {
+    @discardableResult
+    public func saveImage(_ image: NSImage) async throws -> URL {
         let location = saveLocation
         let needsSecurityScope = hasCustomSaveLocation
 
@@ -178,6 +180,7 @@ public final class AppViewModel {
         }
 
         try pngData.write(to: url)
+        return url
     }
 }
 

--- a/BifcodePackage/Sources/BifcodeFeature/Views/ToastView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ToastView.swift
@@ -1,0 +1,200 @@
+//
+//  ToastView.swift
+//
+//  Created on 23.12.2025.
+//  Copyright © 2025 IGR Soft. All rights reserved.
+//
+
+import AppKit
+import SwiftUI
+
+/// The result of an export operation.
+///
+/// Used to communicate export outcomes to the UI for displaying
+/// appropriate toast notifications.
+public enum ExportResult: Sendable {
+    /// Export completed successfully with the file saved at the given URL.
+    case success(URL)
+
+    /// Export failed with the given error.
+    case failure(Error)
+
+    /// Whether the export was successful.
+    var isSuccess: Bool {
+        if case .success = self { return true }
+        return false
+    }
+
+    /// The exported file URL if successful, nil otherwise.
+    var fileURL: URL? {
+        if case .success(let url) = self { return url }
+        return nil
+    }
+
+    /// The error if failed, nil otherwise.
+    var error: Error? {
+        if case .failure(let error) = self { return error }
+        return nil
+    }
+}
+
+/// A toast notification view for displaying export status.
+///
+/// `ToastView` displays a brief, non-blocking notification at the top of the
+/// toolbar area. It shows export success or failure status and provides
+/// an interactive action for successful exports.
+///
+/// ## Overview
+///
+/// The toast appears with a smooth slide-in animation from the top and
+/// automatically dismisses after a configurable timeout. For successful
+/// exports, tapping the toast reveals the exported file in Finder.
+///
+/// ## Usage
+///
+/// ```swift
+/// @State private var exportResult: ExportResult?
+///
+/// var body: some View {
+///     ZStack(alignment: .top) {
+///         // Main content...
+///
+///         if let result = exportResult {
+///             ToastView(result: result) {
+///                 exportResult = nil
+///             }
+///         }
+///     }
+/// }
+/// ```
+///
+/// ## Accessibility
+///
+/// The toast includes VoiceOver support with descriptive labels and hints.
+/// Success toasts announce the action available (reveal in Finder), while
+/// error toasts read the error description.
+public struct ToastView: View {
+    /// The export result to display.
+    let result: ExportResult
+
+    /// Callback when the toast should be dismissed.
+    let onDismiss: () -> Void
+
+    /// Auto-dismiss timeout in seconds.
+    private let dismissTimeout: TimeInterval = 5.0
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    public init(result: ExportResult, onDismiss: @escaping () -> Void) {
+        self.result = result
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        Button(action: handleTap) {
+            HStack(spacing: 8) {
+                Image(systemName: result.isSuccess ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .font(.system(size: 16, weight: .medium))
+
+                Text(message)
+                    .font(.subheadline.weight(.medium))
+                    .lineLimit(1)
+
+                if result.isSuccess {
+                    Image(systemName: "arrow.right.circle")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(backgroundColor)
+            .foregroundStyle(foregroundColor)
+            .clipShape(Capsule())
+            .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 2)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint(result.isSuccess ? "Double-tap to reveal in Finder" : "Double-tap to dismiss")
+        .accessibilityAddTraits(result.isSuccess ? .isButton : [])
+        .transition(.move(edge: .top).combined(with: .opacity))
+        .task {
+            try? await Task.sleep(for: .seconds(dismissTimeout))
+            onDismiss()
+        }
+    }
+
+    // MARK: - Computed Properties
+
+    private var message: String {
+        if result.isSuccess {
+            "Exported successfully"
+        } else if let error = result.error {
+            error.localizedDescription
+        } else {
+            "Export failed"
+        }
+    }
+
+    private var backgroundColor: Color {
+        result.isSuccess ? Color.toastSuccess : Color.toastError
+    }
+
+    private var foregroundColor: Color {
+        .white
+    }
+
+    private var accessibilityLabel: String {
+        if result.isSuccess {
+            "Export successful. Click to reveal file in Finder."
+        } else if let error = result.error {
+            "Export failed: \(error.localizedDescription)"
+        } else {
+            "Export failed"
+        }
+    }
+
+    // MARK: - Actions
+
+    private func handleTap() {
+        if let url = result.fileURL {
+            revealInFinder(url)
+        }
+        onDismiss()
+    }
+
+    private func revealInFinder(_ url: URL) {
+        NSWorkspace.shared.selectFile(
+            url.path,
+            inFileViewerRootedAtPath: url.deletingLastPathComponent().path
+        )
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Success Toast") {
+    VStack {
+        Spacer()
+        ToastView(
+            result: .success(URL(fileURLWithPath: "/Users/test/Desktop/bifcode.png")),
+            onDismiss: {}
+        )
+        Spacer()
+    }
+    .frame(width: 400, height: 200)
+    .background(Color.gray.opacity(0.2))
+}
+
+#Preview("Error Toast") {
+    VStack {
+        Spacer()
+        ToastView(
+            result: .failure(ExportError.conversionFailed),
+            onDismiss: {}
+        )
+        Spacer()
+    }
+    .frame(width: 400, height: 200)
+    .background(Color.gray.opacity(0.2))
+}


### PR DESCRIPTION
## Summary

Add interactive toast notification that displays at toolbar top after export operations, providing immediate feedback and quick access to exported files.

## Changes

- Toast displays at toolbar top with success (green) or error (red) states
- Successful exports allow clicking toast to reveal file in Finder
- Auto-dismisses after 5 seconds with smooth animations
- Respects accessibility preferences (reduce motion)
- Modified `AppViewModel.saveImage()` to return saved file URL
- New `ToastView` component with `ExportResult` enum
- Semantic colors for toast states

## Testing

All existing tests pass. Build succeeds without errors.