### PR TITLE
fix: enable SPM plugin trust in Xcode Cloud

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,2 +1,9 @@
-defaults delete com.apple.dt.Xcode IDEPackageOnlyUseVersionsFromResolvedFile
-defaults delete com.apple.dt.Xcode IDEDisableAutomaticPackageResolution
+#!/bin/bash
+set -e
+
+# Allow automatic package resolution
+defaults delete com.apple.dt.Xcode IDEPackageOnlyUseVersionsFromResolvedFile || true
+defaults delete com.apple.dt.Xcode IDEDisableAutomaticPackageResolution || true
+
+# Trust SPM build plugins (required for SwiftLintPlugin from CodeEditSourceEditor)
+defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES


### PR DESCRIPTION
## Summary
Configures ci_post_clone.sh to skip package plugin fingerprint validation, allowing the SwiftLintPlugin from CodeEditSourceEditor transitive dependency to work in Xcode Cloud builds.

## Changes
- Added proper bash shebang and error handling
- Made defaults delete commands idempotent with || true
- Added IDESkipPackagePluginFingerprintValidatation setting to trust SPM plugins

## Testing
CI/CD Archive workflow should now complete without plugin validation errors.