### PR TITLE
docs: credit CodeEditSourceEditor in README and documentation

### DIFF
--- a/Bifcode.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bifcode.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,123 @@
+{
+  "originHash" : "12c35fbdbe657f2d43e66c49702894fe4acff2e94879d546a9bedf76b8a0b966",
+  "pins" : [
+    {
+      "identity" : "codeeditlanguages",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditLanguages.git",
+      "state" : {
+        "revision" : "331d5dbc5fc8513be5848fce8a2a312908f36a11",
+        "version" : "0.1.20"
+      }
+    },
+    {
+      "identity" : "codeeditsourceeditor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor",
+      "state" : {
+        "revision" : "424453d2232c9912933a3b5a1f3d3df669404ed0",
+        "version" : "0.15.2"
+      }
+    },
+    {
+      "identity" : "codeeditsymbols",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditSymbols.git",
+      "state" : {
+        "revision" : "ae69712b08571c4469c2ed5cd38ad9f19439793e",
+        "version" : "0.2.3"
+      }
+    },
+    {
+      "identity" : "codeedittextview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
+      "state" : {
+        "revision" : "d7ac3f11f22ec2e820187acce8f3a3fb7aa8ddec",
+        "version" : "0.12.1"
+      }
+    },
+    {
+      "identity" : "developersupportstore",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/IGRSoft/DeveloperSupportStore",
+      "state" : {
+        "revision" : "c9d8f3282a649273fdbf4d3841e45e10a4951ee4",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "rearrange",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/Rearrange",
+      "state" : {
+        "revision" : "f1d74e1642956f0300756ad8d1d64e9034857bc3",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "storehelper",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/russell-archer/StoreHelper.git",
+      "state" : {
+        "revision" : "1c55f49473d847fd5a2f495aabe45f6e5ea3e2ef",
+        "version" : "2.7.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swiftlintplugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
+      "state" : {
+        "revision" : "a3877065a7d72ee40e1fa64e13b9e33e846c667c",
+        "version" : "0.63.1"
+      }
+    },
+    {
+      "identity" : "swifttreesitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/SwiftTreeSitter.git",
+      "state" : {
+        "revision" : "08ef81eb8620617b55b08868126707ad72bf754f",
+        "version" : "0.25.0"
+      }
+    },
+    {
+      "identity" : "textformation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/TextFormation",
+      "state" : {
+        "revision" : "b1ce9a14bd86042bba4de62236028dc4ce9db6a1",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "textstory",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/TextStory",
+      "state" : {
+        "revision" : "91df6fc9bd817f9712331a4a3e826f7bdc823e1d",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "tree-sitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter",
+      "state" : {
+        "revision" : "da6fe9beb4f7f67beb75914ca8e0d48ae48d6406",
+        "version" : "0.25.10"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Overview
 
 - **Type**: macOS application
-- **Stack**: Swift 6.2, SwiftUI, HighlightSwift
+- **Stack**: Swift 6.2, SwiftUI, CodeEditSourceEditor
 - **Architecture**: MVVM with @Observable
 - **Platform**: macOS 15.0+ only
 
@@ -157,14 +157,20 @@ BifcodeUITests/                              # UI tests
 
 | Package | Version | Purpose |
 |---------|---------|---------|
-| [HighlightSwift](https://github.com/appstefan/HighlightSwift) | 1.1+ | Syntax highlighting & language auto-detection |
+| [CodeEditSourceEditor](https://github.com/CodeEditApp/CodeEditSourceEditor) | 0.12.0+ | Xcode-inspired code editor with syntax highlighting |
+| [CodeEditLanguages](https://github.com/CodeEditApp/CodeEditLanguages) | 0.1.20+ | Tree-sitter language support (19+ languages) |
+| [DeveloperSupportStore](https://github.com/IGRSoft/DeveloperSupportStore) | 1.0.0+ | In-app purchase support |
 
-### Adding HighlightSwift
+### Adding CodeEditSourceEditor
 
 In Xcode:
 1. File → Add Package Dependencies
-2. URL: `https://github.com/appstefan/highlightswift`
-3. Version: 1.1+
+2. URL: `https://github.com/CodeEditApp/CodeEditSourceEditor`
+3. Version: 0.12.0+
+
+**Support the CodeEditApp project:**
+- ⭐ [Star on GitHub](https://github.com/CodeEditApp/CodeEditSourceEditor)
+- 💖 [Sponsor CodeEditApp](https://github.com/sponsors/CodeEditApp)
 
 ---
 
@@ -172,11 +178,11 @@ In Xcode:
 
 ### Code Editor
 
-- Line numbers (configurable visibility)
-- Syntax highlighting via HighlightSwift `CodeText`
-- Auto-detect language with manual override
+- Syntax highlighting via CodeEditSourceEditor `SourceEditor`
+- 19+ supported languages via CodeEditLanguages
+- 11 syntax themes (7 dark, 4 light)
 - Monospace font (SF Mono or system monospace)
-- Dark theme background
+- Dark and light theme modes
 
 ### Indicator Badge
 
@@ -234,9 +240,9 @@ rg -n "Color\." BifcodePackage/Sources
 # Find all @AppStorage usage
 rg -n "@AppStorage" BifcodePackage/Sources
 
-# Find HighlightSwift usage
-rg -n "import HighlightSwift" BifcodePackage/Sources
-rg -n "CodeText" BifcodePackage/Sources
+# Find CodeEditSourceEditor usage
+rg -n "import CodeEditSourceEditor" BifcodePackage/Sources
+rg -n "SourceEditor" BifcodePackage/Sources
 
 # Find export logic
 rg -n "ImageRenderer\|NSImage" BifcodePackage/Sources
@@ -300,7 +306,7 @@ Standard tools available:
 
 ## Common Gotchas
 
-1. **HighlightSwift Async**: Use `await highlight.attributedText()` for manual highlighting
+1. **CodeEditSourceEditor State**: Use `SourceEditorState` for cursor position and selection management
 2. **ImageRenderer macOS**: Requires `@MainActor` context
 3. **Window Sizing**: Use `GeometryReader` for content-based sizing
 4. **Font Metrics**: SF Mono has different metrics than system fonts

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 A macOS app for creating visual code comparison images — perfect for documentation, tutorials, and style guides showing "Do" vs "Don't" code examples.
 
+## Powered By
+
+<a href="https://github.com/CodeEditApp/CodeEditSourceEditor">
+  <img src="https://img.shields.io/badge/Powered%20by-CodeEditSourceEditor-blue?style=for-the-badge" alt="Powered by CodeEditSourceEditor">
+</a>
+
+Bifcode's code editor is built on [**CodeEditSourceEditor**](https://github.com/CodeEditApp/CodeEditSourceEditor) — an Xcode-inspired code editor component from the [CodeEditApp](https://github.com/CodeEditApp) team.
+
+**Support the project:**
+- ⭐ [Star CodeEditSourceEditor on GitHub](https://github.com/CodeEditApp/CodeEditSourceEditor)
+- 🏠 [Check out CodeEdit](https://github.com/CodeEditApp/CodeEdit) — A native macOS code editor
+- 💖 [Sponsor CodeEditApp](https://github.com/sponsors/CodeEditApp)
+
 ## Features
 
 ### Code Editor


### PR DESCRIPTION
## Summary

Add prominent "Powered By" section to README.md crediting CodeEditSourceEditor, and update outdated CLAUDE.md documentation that referenced HighlightSwift instead of the current CodeEditSourceEditor implementation.

## Changes

- Added "Powered By" badge and section in README with links to star the project, explore CodeEdit, and sponsor CodeEditApp
- Updated CLAUDE.md Stack reference from HighlightSwift to CodeEditSourceEditor
- Replaced dependencies table with current packages: CodeEditSourceEditor, CodeEditLanguages, DeveloperSupportStore
- Updated Code Editor feature specs and architecture search commands to reflect current implementation