### PR TITLE
#34 feat: add more programming languages

### DIFF
--- a/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
+++ b/BifcodePackage/Sources/BifcodeFeature/Views/ToolBarView.swift
@@ -298,10 +298,17 @@ public struct ToolBarView: View {
     
     private var commonLanguages: [CodeLanguage] {
         [
+            // Popular languages
             .swift, .python, .javascript, .typescript,
             .java, .kotlin, .go, .rust, .ruby,
             .c, .cpp, .cSharp, .php, .sql,
-            .html, .css, .json, .yaml, .bash
+            // Web & markup
+            .html, .css, .json, .yaml, .markdown,
+            // DevOps & config
+            .bash, .dockerfile, .toml,
+            // Functional & other
+            .scala, .elixir, .haskell, .lua,
+            .dart, .julia, .perl, .zig
         ]
     }
     


### PR DESCRIPTION
## Motivation
Users work with many languages beyond the original 19.

## Changes
- Add Markdown, Dockerfile, TOML to DevOps & config section
- Add Scala, Elixir, Haskell, Lua to functional languages  
- Add Dart, Julia, Perl, Zig as additional popular languages
- Organize languages into logical groups with comments

## Languages Added
| Group | Languages |
|-------|-----------|
| Web & markup | Markdown |
| DevOps & config | Dockerfile, TOML |
| Functional | Scala, Elixir, Haskell, Lua |
| Other | Dart, Julia, Perl, Zig |

## Notes
- Terraform and GraphQL from the issue are not available in CodeEditLanguages
- Total languages now: 27 (up from 19)