### PR TITLE
build: bump CodeEditSourceEditor to 0.15.0 and DeveloperSupportStore to 1.0.3

### DIFF
--- a/Bifcode.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bifcode.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "12c35fbdbe657f2d43e66c49702894fe4acff2e94879d546a9bedf76b8a0b966",
+  "originHash" : "940797f4df50fc3ed2854a3b92465fc27d52127b53e5d66f7742a229653030a0",
   "pins" : [
     {
       "identity" : "codeeditlanguages",
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
       }
     },
     {

--- a/BifcodePackage/Package.swift
+++ b/BifcodePackage/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/CodeEditApp/CodeEditSourceEditor", from: "0.12.0"),
-        .package(url: "https://github.com/IGRSoft/DeveloperSupportStore", from: "1.0.0")
+        .package(url: "https://github.com/CodeEditApp/CodeEditSourceEditor", from: "0.15.0"),
+        .package(url: "https://github.com/IGRSoft/DeveloperSupportStore", from: "1.0.3")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Motivation
Update core dependencies to their latest versions for bug fixes and improvements.

## Changes
- Bump CodeEditSourceEditor from 0.12.0 to 0.15.0
- Bump DeveloperSupportStore from 1.0.0 to 1.0.3
- swift-collections resolved version updated to 1.4.1